### PR TITLE
ci: bump Dockerfile base image from node:16 to node:22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build Stage
-FROM node:16 AS build-stage
+FROM node:22 AS build-stage
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
## Summary

Fixes Fly.io deployment which started failing after PR #14 was merged.

## Problem

The Dockerfile was pinned to `node:16`, but Vite 5 requires Node 18+ (it uses `crypto.getRandomValues`). Fly deploy log:

```
error during build:
TypeError: crypto$2.getRandomValues is not a function
    at resolveConfig (file:///app/node_modules/vite/dist/node/chunks/dep-BK3b2jBa.js:66671:16)
```

## Fix

Bump the build stage base image from `node:16` to `node:22` to match CI.