### PR TITLE
feat(shortcuts): configurable form and graph shortcuts

### DIFF
--- a/src/components/D3EdgeForm.vue
+++ b/src/components/D3EdgeForm.vue
@@ -3,11 +3,8 @@
     id="iform"
     ref="formfields"
     class="fx-panel"
-    @keyup.alt.s="updateEdge()"
-    @keyup.meta.s="updateEdge()"
-    @keyup.ctrl.c="close()"
-    @keyup.meta.c="close()"
-    @keydown.esc="keyPress($event)"
+    @keyup="onKeyup($event)"
+    @keydown="onKeydown($event)"
     @keypress.stop.prevent="keyPress($event)"
   >
     <focus-trap v-model:active="enableTrap">
@@ -19,7 +16,15 @@
             </span>
             <h2 class="fx-title">EDGE</h2>
           </div>
-          <button type="button" class="fx-close" @click="close()" @keypress.stop="" aria-label="Close">✕</button>
+          <button
+            type="button"
+            class="fx-close"
+            @click="close()"
+            @keypress.stop=""
+            aria-label="Close"
+          >
+            ✕
+          </button>
         </header>
 
         <div class="fx-readout">
@@ -48,7 +53,9 @@
                   @click.stop="toggleSel('arrowStyle')"
                   @keypress.stop=""
                   @keydown.down.prevent="openAndFocus('arrowStyle', $event)"
-                >{{ arrowStyleLabel }}<span class="fx-caret">▾</span></button>
+                >
+                  {{ arrowStyleLabel }}<span class="fx-caret">▾</span>
+                </button>
                 <transition name="fx-drop">
                   <ul v-if="openSel === 'arrowStyle'" class="fx-options">
                     <li
@@ -65,7 +72,9 @@
                       @keydown.k.prevent="focusPrev($event)"
                       @keydown.j.prevent="focusNext($event)"
                       @keydown.esc.stop="closeSel($event)"
-                    >{{ opt.label }}</li>
+                    >
+                      {{ opt.label }}
+                    </li>
                   </ul>
                 </transition>
               </div>
@@ -80,7 +89,9 @@
                   @click.stop="toggleSel('arrow')"
                   @keypress.stop=""
                   @keydown.down.prevent="openAndFocus('arrow', $event)"
-                >{{ arrowLabel }}<span class="fx-caret">▾</span></button>
+                >
+                  {{ arrowLabel }}<span class="fx-caret">▾</span>
+                </button>
                 <transition name="fx-drop">
                   <ul v-if="openSel === 'arrow'" class="fx-options">
                     <li
@@ -97,7 +108,9 @@
                       @keydown.k.prevent="focusPrev($event)"
                       @keydown.j.prevent="focusNext($event)"
                       @keydown.esc.stop="closeSel($event)"
-                    >{{ opt.label }}</li>
+                    >
+                      {{ opt.label }}
+                    </li>
                   </ul>
                 </transition>
               </div>
@@ -107,11 +120,23 @@
           <div class="fx-grid fx-grid-2">
             <label class="fx-field">
               <span class="fx-label">From Node</span>
-              <input class="fx-input fx-input-static" type="text" v-model="fromNode" readonly placeholder="select source" />
+              <input
+                class="fx-input fx-input-static"
+                type="text"
+                v-model="fromNode"
+                readonly
+                placeholder="select source"
+              />
             </label>
             <label class="fx-field">
               <span class="fx-label">To Node</span>
-              <input class="fx-input fx-input-static" type="text" v-model="toNode" readonly placeholder="select target" />
+              <input
+                class="fx-input fx-input-static"
+                type="text"
+                v-model="toNode"
+                readonly
+                placeholder="select target"
+              />
             </label>
           </div>
 
@@ -124,8 +149,6 @@
               :rows="edgeRows"
               placeholder="Add edge label... can be html ... {{ shortcutLabels.clear }} to clear value"
               @keypress.stop=""
-              @keydown.alt.shift.w="edgeLabel=''"
-              @keydown.meta.shift.w="edgeLabel=''"
             ></textarea>
           </label>
 
@@ -139,7 +162,9 @@
                   @click.stop="toggleSel('sourceArrowhead')"
                   @keypress.stop=""
                   @keydown.down.prevent="openAndFocus('sourceArrowhead', $event)"
-                >{{ sourceArrowLabel }}<span class="fx-caret">▾</span></button>
+                >
+                  {{ sourceArrowLabel }}<span class="fx-caret">▾</span>
+                </button>
                 <transition name="fx-drop">
                   <ul v-if="openSel === 'sourceArrowhead'" class="fx-options">
                     <li
@@ -154,7 +179,9 @@
                       @keydown.k.prevent="focusPrev($event)"
                       @keydown.j.prevent="focusNext($event)"
                       @keydown.esc.stop="closeSel($event)"
-                    >— none —</li>
+                    >
+                      — none —
+                    </li>
                     <li
                       v-for="opt in edgeArrowHeadOptions"
                       :key="opt.value"
@@ -169,7 +196,9 @@
                       @keydown.k.prevent="focusPrev($event)"
                       @keydown.j.prevent="focusNext($event)"
                       @keydown.esc.stop="closeSel($event)"
-                    >{{ opt.label }}</li>
+                    >
+                      {{ opt.label }}
+                    </li>
                   </ul>
                 </transition>
               </div>
@@ -206,7 +235,9 @@
                   @click="edgeColor = ''"
                   @keypress.stop=""
                   title="Use theme color"
-                >none</button>
+                >
+                  none
+                </button>
               </div>
             </label>
 
@@ -219,7 +250,9 @@
                   @click.stop="toggleSel('lineStyle')"
                   @keypress.stop=""
                   @keydown.down.prevent="openAndFocus('lineStyle', $event)"
-                >{{ lineStyleLabel }}<span class="fx-caret">▾</span></button>
+                >
+                  {{ lineStyleLabel }}<span class="fx-caret">▾</span>
+                </button>
                 <transition name="fx-drop">
                   <ul v-if="openSel === 'lineStyle'" class="fx-options">
                     <li
@@ -236,7 +269,9 @@
                       @keydown.k.prevent="focusPrev($event)"
                       @keydown.j.prevent="focusNext($event)"
                       @keydown.esc.stop="closeSel($event)"
-                    >{{ opt.label }}</li>
+                    >
+                      {{ opt.label }}
+                    </li>
                   </ul>
                 </transition>
               </div>
@@ -251,7 +286,9 @@
                   @click.stop="toggleSel('curve')"
                   @keypress.stop=""
                   @keydown.down.prevent="openAndFocus('curve', $event)"
-                >{{ edgeCurveLabel }}<span class="fx-caret">▾</span></button>
+                >
+                  {{ edgeCurveLabel }}<span class="fx-caret">▾</span>
+                </button>
                 <transition name="fx-drop">
                   <ul v-if="openSel === 'curve'" class="fx-options">
                     <li
@@ -268,7 +305,9 @@
                       @keydown.k.prevent="focusPrev($event)"
                       @keydown.j.prevent="focusNext($event)"
                       @keydown.esc.stop="closeSel($event)"
-                    >{{ opt.label }}</li>
+                    >
+                      {{ opt.label }}
+                    </li>
                   </ul>
                 </transition>
               </div>
@@ -297,20 +336,21 @@
             class="fx-btn fx-btn-primary"
             @click="updateEdge()"
             @keypress.stop=""
-          >Update Edge <span class="fx-kbd">{{ shortcutLabels.save }}</span></button>
+          >
+            Update Edge <span class="fx-kbd">{{ shortcutLabels.save }}</span>
+          </button>
           <button
             v-else
             type="button"
             class="fx-btn fx-btn-primary"
             @click="addEdge()"
             @keypress.stop=""
-          >Add Edge <span class="fx-kbd">{{ shortcutLabels.save }}</span></button>
-          <button
-            type="button"
-            class="fx-btn fx-btn-ghost"
-            @click="close()"
-            @keypress.stop=""
-          >Cancel <span class="fx-kbd">{{ shortcutLabels.close }}</span></button>
+          >
+            Add Edge <span class="fx-kbd">{{ shortcutLabels.save }}</span>
+          </button>
+          <button type="button" class="fx-btn fx-btn-ghost" @click="close()" @keypress.stop="">
+            Cancel <span class="fx-kbd">{{ shortcutLabels.close }}</span>
+          </button>
         </footer>
       </div>
     </focus-trap>
@@ -319,11 +359,12 @@
 
 <script>
 import D3Util from '@/helpers/D3Util'
+import Shortcuts from '@/helpers/Shortcuts.js'
 export default {
   name: 'D3Edge',
   props: ['active', 'd3Data'],
   inject: ['modifier'],
-  data () {
+  data() {
     return {
       edgeModal: false,
       edgeLabel: '',
@@ -361,17 +402,41 @@ export default {
       return D3Util.edgeCurveOptions()
     },
     arrowStyleLabel() {
-      return this._optLabel(this.edgeArrowHeadStyleOptions, this.edgeArrowHeadStyle, 'value', 'label', 'Filled')
+      return this._optLabel(
+        this.edgeArrowHeadStyleOptions,
+        this.edgeArrowHeadStyle,
+        'value',
+        'label',
+        'Filled'
+      )
     },
     arrowLabel() {
-      return this._optLabel(this.edgeArrowHeadOptions, this.edgeArrowHead, 'value', 'label', 'Triangle')
+      return this._optLabel(
+        this.edgeArrowHeadOptions,
+        this.edgeArrowHead,
+        'value',
+        'label',
+        'Triangle'
+      )
     },
     sourceArrowLabel() {
       if (!this.sourceArrowhead) return '— none —'
-      return this._optLabel(this.edgeArrowHeadOptions, this.sourceArrowhead, 'value', 'label', this.sourceArrowhead)
+      return this._optLabel(
+        this.edgeArrowHeadOptions,
+        this.sourceArrowhead,
+        'value',
+        'label',
+        this.sourceArrowhead
+      )
     },
     lineStyleLabel() {
-      return this._optLabel(this.edgeLineStyleOptions, this.edgeLineStyle, 'value', 'label', '— theme —')
+      return this._optLabel(
+        this.edgeLineStyleOptions,
+        this.edgeLineStyle,
+        'value',
+        'label',
+        '— theme —'
+      )
     },
     edgeCurveLabel() {
       return this._optLabel(this.edgeCurveOptions, this.edgeCurve, 'value', 'label', '— theme —')
@@ -384,9 +449,9 @@ export default {
     edgeRows() {
       const count = (this.edgeLabel || '').split('\n').length
       return Math.min(6, Math.max(2, count))
-    },
+    }
   },
-  mounted () {
+  mounted() {
     document.addEventListener('click', this.onDocClick)
 
     if (this.edgeModal) {
@@ -400,21 +465,22 @@ export default {
       })
     }
   },
-  beforeUnmount () {
+  beforeUnmount() {
     document.removeEventListener('click', this.onDocClick)
   },
   methods: {
     _populate() {
       // Derive from the prop every time: the immediate d3Data watcher runs
       // before created(), so we can't rely on update/edgeModal being set yet.
-      this.update    = this.active == 'Edit Edge'
+      this.update = this.active == 'Edit Edge'
       this.edgeModal = this.active == 'Edit Edge' || this.active == 'Add Edge'
-      if (D3Util.debug) console.log('[D3EdgeForm] _populate', {
-        active:    this.active,
-        update:    this.update,
-        edgeModal: this.edgeModal,
-        d3Data:    this.d3Data,
-      })
+      if (D3Util.debug)
+        console.log('[D3EdgeForm] _populate', {
+          active: this.active,
+          update: this.update,
+          edgeModal: this.edgeModal,
+          d3Data: this.d3Data
+        })
       if (!(this.update || this.edgeModal)) return
       const mod = this.modifier?.value ?? this.modifier
       this.edgeId = this.d3Data?.id
@@ -432,15 +498,15 @@ export default {
         // Create mode: start from the configurable edge creation defaults in
         // Settings so a new line inherits the user's preferred look.
         const d = D3Util.defaultEdgeValues()
-        this.edgeLabel          = d.edgeLabel
+        this.edgeLabel = d.edgeLabel
         this.edgeArrowHeadStyle = d.edgeArrowHeadStyle
-        this.edgeArrowHead      = d.edgeArrowHead
-        this.sourceArrowhead    = d.sourceArrowhead
-        this.edgeWidth          = d.edgeWidth
-        this.edgeColor          = d.edgeColor
-        this.edgeLineStyle      = d.edgeLineStyle
-        this.edgeCurve          = d.edgeCurve
-        this.edgeOpacity        = d.edgeOpacity
+        this.edgeArrowHead = d.edgeArrowHead
+        this.sourceArrowhead = d.sourceArrowhead
+        this.edgeWidth = d.edgeWidth
+        this.edgeColor = d.edgeColor
+        this.edgeLineStyle = d.edgeLineStyle
+        this.edgeCurve = d.edgeCurve
+        this.edgeOpacity = d.edgeOpacity
       }
 
       let srcId = null
@@ -455,26 +521,27 @@ export default {
         srcId = this.edgeId.v
         tgtId = this.edgeId.w
       }
-      this.fromNode = srcId ? (mod.getNodeData(srcId)?.label || srcId) : ''
-      this.toNode = tgtId ? (mod.getNodeData(tgtId)?.label || tgtId) : ''
-      if (D3Util.debug) console.log('[D3EdgeForm] fields', {
-        edgeId:    this.edgeId,
-        edgeLabel: this.edgeLabel,
-        edgeArrowHeadStyle: this.edgeArrowHeadStyle,
-        edgeArrowHead: this.edgeArrowHead,
-        sourceArrowhead: this.sourceArrowhead,
-        edgeWidth: this.edgeWidth,
-        edgeColor: this.edgeColor,
-        edgeLineStyle: this.edgeLineStyle,
-        edgeCurve: this.edgeCurve,
-        edgeOpacity: this.edgeOpacity,
-        fromNode:  this.fromNode,
-        toNode:    this.toNode,
-      })
+      this.fromNode = srcId ? mod.getNodeData(srcId)?.label || srcId : ''
+      this.toNode = tgtId ? mod.getNodeData(tgtId)?.label || tgtId : ''
+      if (D3Util.debug)
+        console.log('[D3EdgeForm] fields', {
+          edgeId: this.edgeId,
+          edgeLabel: this.edgeLabel,
+          edgeArrowHeadStyle: this.edgeArrowHeadStyle,
+          edgeArrowHead: this.edgeArrowHead,
+          sourceArrowhead: this.sourceArrowhead,
+          edgeWidth: this.edgeWidth,
+          edgeColor: this.edgeColor,
+          edgeLineStyle: this.edgeLineStyle,
+          edgeCurve: this.edgeCurve,
+          edgeOpacity: this.edgeOpacity,
+          fromNode: this.fromNode,
+          toNode: this.toNode
+        })
     },
     _optLabel(list, val, valKey, labelKey, fallback) {
       if (!val) return fallback
-      const opt = list.find(o => o[valKey] === val)
+      const opt = list.find((o) => o[valKey] === val)
       return opt ? opt[labelKey] : fallback
     },
     toggleSel(key) {
@@ -512,7 +579,7 @@ export default {
     onDocClick() {
       this.openSel = null
     },
-    updateEdge () {
+    updateEdge() {
       const mod = this.modifier?.value ?? this.modifier
       mod.updateEdge(this.$data, this.edgeId)
       this.close()
@@ -520,12 +587,30 @@ export default {
     keyPress(event) {
       this.hints = D3Util.formHints(event, this)
     },
-    addEdge () {
+    onKeydown(event) {
+      if (Shortcuts.matches(event, 'close')) {
+        event.preventDefault()
+        this.close()
+        return
+      }
+      if (Shortcuts.matches(event, 'clear')) {
+        event.preventDefault()
+        this.edgeLabel = ''
+      }
+    },
+    onKeyup(event) {
+      if (event.repeat) return
+      if (Shortcuts.matches(event, 'save')) {
+        event.preventDefault()
+        this.updateEdge()
+      }
+    },
+    addEdge() {
       const mod = this.modifier?.value ?? this.modifier
       mod.addEdge(this.$data)
       this.common()
     },
-    close () {
+    close() {
       this.common()
     },
     common() {
@@ -536,7 +621,7 @@ export default {
   },
   watch: {
     active(val) {
-      this.update    = val == 'Edit Edge'
+      this.update = val == 'Edit Edge'
       this.edgeModal = val == 'Edit Edge' || val == 'Add Edge'
       this._populate()
     },
@@ -544,9 +629,9 @@ export default {
       handler() {
         this._populate()
       },
-      immediate: true,
-    },
-  },
+      immediate: true
+    }
+  }
 }
 </script>
 

--- a/src/components/D3NodeForm.vue
+++ b/src/components/D3NodeForm.vue
@@ -3,11 +3,8 @@
     id="iform"
     ref="formfields"
     class="fx-panel"
-    @keyup.alt.s="updateNode()"
-    @keyup.meta.s="updateNode()"
-    @keyup.ctrl.c="close()"
-    @keyup.meta.c="close()"
-    @keydown.esc="keyPress($event)"
+    @keyup="onKeyup($event)"
+    @keydown="onKeydown($event)"
     @keypress.stop.prevent="keyPress($event)"
   >
     <focus-trap v-model:active="enableTrap">
@@ -19,7 +16,15 @@
             </span>
             <h2 class="fx-title">NODE</h2>
           </div>
-          <button type="button" class="fx-close" @click="close()" @keypress.stop="" aria-label="Close">✕</button>
+          <button
+            type="button"
+            class="fx-close"
+            @click="close()"
+            @keypress.stop=""
+            aria-label="Close"
+          >
+            ✕
+          </button>
         </header>
 
         <div class="fx-readout">
@@ -48,7 +53,9 @@
                   @click.stop="toggleSel('shape')"
                   @keypress.stop=""
                   @keydown.down.prevent="openAndFocus('shape', $event)"
-                >{{ shapeLabel }}<span class="fx-caret">▾</span></button>
+                >
+                  {{ shapeLabel }}<span class="fx-caret">▾</span>
+                </button>
                 <transition name="fx-drop">
                   <ul v-if="openSel === 'shape'" class="fx-options">
                     <li
@@ -65,7 +72,9 @@
                       @keydown.k.prevent="focusPrev($event)"
                       @keydown.j.prevent="focusNext($event)"
                       @keydown.esc.stop="closeSel($event)"
-                    >{{ opt.label }}</li>
+                    >
+                      {{ opt.label }}
+                    </li>
                   </ul>
                 </transition>
               </div>
@@ -80,12 +89,17 @@
                   @click.stop="toggleSel('halign')"
                   @keypress.stop=""
                   @keydown.down.prevent="openAndFocus('halign', $event)"
-                >{{ textHalign }}<span class="fx-caret">▾</span></button>
+                >
+                  {{ textHalign }}<span class="fx-caret">▾</span>
+                </button>
                 <transition name="fx-drop">
                   <ul v-if="openSel === 'halign'" class="fx-options">
-                    <li v-for="opt in halignOptions" :key="opt.value"
+                    <li
+                      v-for="opt in halignOptions"
+                      :key="opt.value"
                       tabindex="0"
-                      class="fx-option" :class="{ 'fx-option-active': textHalign === opt.value }"
+                      class="fx-option"
+                      :class="{ 'fx-option-active': textHalign === opt.value }"
                       @click="pick('textHalign', opt.value)"
                       @keydown.enter.prevent="pick('textHalign', opt.value)"
                       @keydown.space.prevent="pick('textHalign', opt.value)"
@@ -94,7 +108,9 @@
                       @keydown.k.prevent="focusPrev($event)"
                       @keydown.j.prevent="focusNext($event)"
                       @keydown.esc.stop="closeSel($event)"
-                    >{{ opt.label }}</li>
+                    >
+                      {{ opt.label }}
+                    </li>
                   </ul>
                 </transition>
               </div>
@@ -109,12 +125,17 @@
                   @click.stop="toggleSel('valign')"
                   @keypress.stop=""
                   @keydown.down.prevent="openAndFocus('valign', $event)"
-                >{{ textValign }}<span class="fx-caret">▾</span></button>
+                >
+                  {{ textValign }}<span class="fx-caret">▾</span>
+                </button>
                 <transition name="fx-drop">
                   <ul v-if="openSel === 'valign'" class="fx-options">
-                    <li v-for="opt in valignOptions" :key="opt.value"
+                    <li
+                      v-for="opt in valignOptions"
+                      :key="opt.value"
                       tabindex="0"
-                      class="fx-option" :class="{ 'fx-option-active': textValign === opt.value }"
+                      class="fx-option"
+                      :class="{ 'fx-option-active': textValign === opt.value }"
                       @click="pick('textValign', opt.value)"
                       @keydown.enter.prevent="pick('textValign', opt.value)"
                       @keydown.space.prevent="pick('textValign', opt.value)"
@@ -123,7 +144,9 @@
                       @keydown.k.prevent="focusPrev($event)"
                       @keydown.j.prevent="focusNext($event)"
                       @keydown.esc.stop="closeSel($event)"
-                    >{{ opt.label }}</li>
+                    >
+                      {{ opt.label }}
+                    </li>
                   </ul>
                 </transition>
               </div>
@@ -138,7 +161,9 @@
                   @click.stop="toggleSel('parent')"
                   @keypress.stop=""
                   @keydown.down.prevent="openAndFocus('parent', $event)"
-                >{{ parentLabel }}<span class="fx-caret">▾</span></button>
+                >
+                  {{ parentLabel }}<span class="fx-caret">▾</span>
+                </button>
                 <transition name="fx-drop">
                   <div v-if="openSel === 'parent'" class="fx-options">
                     <input
@@ -168,7 +193,9 @@
                         @keydown.k.prevent="focusPrev($event)"
                         @keydown.j.prevent="focusNext($event)"
                         @keydown.esc.stop="closeSel($event)"
-                      >— none —</li>
+                      >
+                        — none —
+                      </li>
                       <li
                         v-for="opt in filteredParentOptions"
                         :key="opt.key"
@@ -183,7 +210,9 @@
                         @keydown.k.prevent="focusPrev($event)"
                         @keydown.j.prevent="focusNext($event)"
                         @keydown.esc.stop="closeSel($event)"
-                      >{{ opt.value }}</li>
+                      >
+                        {{ opt.value }}
+                      </li>
                     </ul>
                   </div>
                 </transition>
@@ -200,8 +229,6 @@
               :rows="labelRows"
               placeholder="Add a node label ... if label contains HTML then Label Type must be Html ... {{ shortcutLabels.clear }} to clear value"
               @keypress.stop=""
-              @keydown.alt.shift.w="nodeLabel=''"
-              @keydown.meta.shift.w="nodeLabel=''"
             ></textarea>
           </label>
 
@@ -223,7 +250,9 @@
                   @click="bgColor = ''"
                   @keypress.stop=""
                   title="Use theme color"
-                >none</button>
+                >
+                  none
+                </button>
               </div>
             </label>
 
@@ -244,7 +273,9 @@
                   @click="borderColor = ''"
                   @keypress.stop=""
                   title="Use theme color"
-                >none</button>
+                >
+                  none
+                </button>
               </div>
             </label>
 
@@ -285,20 +316,21 @@
             class="fx-btn fx-btn-primary"
             @click="updateNode()"
             @keypress.stop=""
-          >Update Node <span class="fx-kbd">{{ shortcutLabels.save }}</span></button>
+          >
+            Update Node <span class="fx-kbd">{{ shortcutLabels.save }}</span>
+          </button>
           <button
             v-else
             type="button"
             class="fx-btn fx-btn-primary"
             @click="addNode()"
             @keypress.stop=""
-          >Add Node</button>
-          <button
-            type="button"
-            class="fx-btn fx-btn-ghost"
-            @click="close()"
-            @keypress.stop=""
-          >Cancel <span class="fx-kbd">{{ shortcutLabels.close }}</span></button>
+          >
+            Add Node
+          </button>
+          <button type="button" class="fx-btn fx-btn-ghost" @click="close()" @keypress.stop="">
+            Cancel <span class="fx-kbd">{{ shortcutLabels.close }}</span>
+          </button>
         </footer>
       </div>
     </focus-trap>
@@ -307,11 +339,12 @@
 
 <script>
 import D3Util from '@/helpers/D3Util'
+import Shortcuts from '@/helpers/Shortcuts.js'
 export default {
   name: 'D3Node',
   props: ['active', 'd3Data'],
   inject: ['modifier'],
-  data () {
+  data() {
     return {
       enableTrap: false,
       errorClass: true,
@@ -329,10 +362,10 @@ export default {
       bgColor: '',
       borderColor: '',
       borderWidth: null,
-      fontSize: null,
+      fontSize: null
     }
   },
-  mounted () {
+  mounted() {
     document.addEventListener('click', this.onDocClick)
 
     this.$nextTick(() => {
@@ -343,21 +376,24 @@ export default {
       this.enableTrap = true
       if (this.$refs.nodeLabelTextField) this.$refs.nodeLabelTextField.focus()
       if (D3Util.debug) {
-        const root  = this.$refs.formfields
-        const trig  = root ? [...root.querySelectorAll('.fx-select-trigger')] : []
+        const root = this.$refs.formfields
+        const trig = root ? [...root.querySelectorAll('.fx-select-trigger')] : []
         const style = root ? root.querySelector('input.fx-input') : null
-        console.log('[D3NodeForm] dom', JSON.stringify({
-          triggers: trig.map(b => b.textContent),
-          triggerColors: trig.map(b => getComputedStyle(b).color),
-          triggerBg: trig.map(b => getComputedStyle(b).backgroundColor),
-          styleInput: style ? style.value : null,
-          styleInputColor: style ? getComputedStyle(style).color : null,
-          panelBg: root ? getComputedStyle(root).backgroundColor : null,
-        }))
+        console.log(
+          '[D3NodeForm] dom',
+          JSON.stringify({
+            triggers: trig.map((b) => b.textContent),
+            triggerColors: trig.map((b) => getComputedStyle(b).color),
+            triggerBg: trig.map((b) => getComputedStyle(b).backgroundColor),
+            styleInput: style ? style.value : null,
+            styleInputColor: style ? getComputedStyle(style).color : null,
+            panelBg: root ? getComputedStyle(root).backgroundColor : null
+          })
+        )
       }
     })
   },
-  beforeUnmount () {
+  beforeUnmount() {
     document.removeEventListener('click', this.onDocClick)
   },
   computed: {
@@ -377,15 +413,17 @@ export default {
       const mod = this.modifier?.value ?? this.modifier
       if (!mod || !mod.cy) return []
       return mod.cy.nodes().map((n) => ({
-        key:   n.id(),
-        value: n.data('label') || n.id(),
+        key: n.id(),
+        value: n.data('label') || n.id()
       }))
     },
     filteredParentOptions() {
       if (!this.parentSearch) return this.parentOptions
       const q = this.parentSearch.toLowerCase()
-      return this.parentOptions.filter(o =>
-        String(o.value || o.key).toLowerCase().startsWith(q)
+      return this.parentOptions.filter((o) =>
+        String(o.value || o.key)
+          .toLowerCase()
+          .startsWith(q)
       )
     },
     shapeLabel() {
@@ -393,7 +431,7 @@ export default {
     },
     parentLabel() {
       if (!this.parentNode) return '— none —'
-      const opt = this.parentOptions.find(o => o.key === this.parentNode)
+      const opt = this.parentOptions.find((o) => o.key === this.parentNode)
       return opt ? opt.value : this.parentNode
     },
     posText() {
@@ -408,63 +446,68 @@ export default {
     labelRows() {
       const count = (this.nodeLabel || '').split('\n').length
       return Math.min(8, Math.max(3, count))
-    },
+    }
   },
   methods: {
     _populate() {
       // Derive from the prop every time: the immediate d3Data watcher runs
       // before created(), so we can't rely on this.update being set yet.
       this.update = this.active == 'Edit Node'
-      if (D3Util.debug) console.log('[D3NodeForm] _populate', {
-        active: this.active,
-        update: this.update,
-        hasId:  !!this.d3Data?.id,
-        d3Data: this.d3Data,
-      })
+      if (D3Util.debug)
+        console.log('[D3NodeForm] _populate', {
+          active: this.active,
+          update: this.update,
+          hasId: !!this.d3Data?.id,
+          d3Data: this.d3Data
+        })
       if (!(this.update && this.d3Data?.id)) {
         // Create mode: start from the configurable node creation defaults in
         // Settings so a new node inherits the user's preferred look.
         const d = D3Util.defaultNodeValues()
-        this.nodeLabel   = d.nodeLabel
-        this.nodeShape   = d.nodeShape
-        this.nodeId      = null
-        this.parentNode  = null
-        this.textHalign  = d.textHalign
-        this.textValign  = d.textValign
-        this.bgColor     = d.bgColor     || ''
+        this.nodeLabel = d.nodeLabel
+        this.nodeShape = d.nodeShape
+        this.nodeId = null
+        this.parentNode = null
+        this.textHalign = d.textHalign
+        this.textValign = d.textValign
+        this.bgColor = d.bgColor || ''
         this.borderColor = d.borderColor || ''
         this.borderWidth = d.borderWidth != null ? d.borderWidth : null
-        this.fontSize    = d.fontSize    != null ? d.fontSize : null
+        this.fontSize = d.fontSize != null ? d.fontSize : null
         return
       }
       const mod = this.modifier?.value ?? this.modifier
-      this.nodeLabel  = this.d3Data.label
-      this.nodeShape  = this.d3Data.nodeShape || this.d3Data.shape
-      this.nodeId     = this.d3Data.id
-      const parentEl  = mod?.cy?.getElementById(this.d3Data.id)?.parent()?.first()
+      this.nodeLabel = this.d3Data.label
+      this.nodeShape = this.d3Data.nodeShape || this.d3Data.shape
+      this.nodeId = this.d3Data.id
+      const parentEl = mod?.cy?.getElementById(this.d3Data.id)?.parent()?.first()
       this.parentNode = parentEl?.length ? parentEl.id() : null
       this.textHalign = this.d3Data.textHalign || 'center'
       this.textValign = this.d3Data.textValign || 'top'
-      this.bgColor    = this.d3Data.bgColor || ''
+      this.bgColor = this.d3Data.bgColor || ''
       this.borderColor = this.d3Data.borderColor || ''
       this.borderWidth = this.d3Data.borderWidth ?? null
-      this.fontSize    = this.d3Data.fontSize ?? null
-      if (D3Util.debug) console.log('[D3NodeForm] fields', JSON.stringify({
-        nodeLabel:  this.nodeLabel,
-        nodeShape:  this.nodeShape,
-        nodeId:     this.nodeId,
-        parentNode: this.parentNode,
-        textHalign: this.textHalign,
-        textValign: this.textValign,
-        bgColor:    this.bgColor,
-        borderColor: this.borderColor,
-        borderWidth: this.borderWidth,
-        fontSize:   this.fontSize,
-      }))
+      this.fontSize = this.d3Data.fontSize ?? null
+      if (D3Util.debug)
+        console.log(
+          '[D3NodeForm] fields',
+          JSON.stringify({
+            nodeLabel: this.nodeLabel,
+            nodeShape: this.nodeShape,
+            nodeId: this.nodeId,
+            parentNode: this.parentNode,
+            textHalign: this.textHalign,
+            textValign: this.textValign,
+            bgColor: this.bgColor,
+            borderColor: this.borderColor,
+            borderWidth: this.borderWidth,
+            fontSize: this.fontSize
+          })
+        )
     },
     _optLabel(list, val, valKey, labelKey, fallback) {
       if (!val) return fallback
-      const opt = list.find(o => o[valKey] === val)
+      const opt = list.find((o) => o[valKey] === val)
       return opt ? opt[labelKey] : fallback
     },
     toggleSel(key) {
@@ -475,7 +518,10 @@ export default {
       this.$nextTick(() => {
         const container = event.currentTarget.closest('.fx-select')
         const searchInput = container?.querySelector('.fx-option-search')
-        if (searchInput) { searchInput.focus(); return }
+        if (searchInput) {
+          searchInput.focus()
+          return
+        }
         const ul = container?.querySelector('.fx-options')
         if (ul) {
           const target = ul.querySelector('.fx-option-active') || ul.querySelector('.fx-option')
@@ -491,7 +537,10 @@ export default {
     },
     focusPrev(event) {
       const prev = event.target.previousElementSibling
-      if (prev) { prev.focus(); return }
+      if (prev) {
+        prev.focus()
+        return
+      }
       const container = event.target.closest('.fx-select')
       const searchInput = container?.querySelector('.fx-option-search')
       if (searchInput) searchInput.focus()
@@ -513,21 +562,43 @@ export default {
     onDocClick() {
       this.openSel = null
     },
-    updateNode () {
+    updateNode() {
       const mod = this.modifier?.value ?? this.modifier
-      console.log('[D3NodeForm] updateNode clicked', { nodeId: this.nodeId, nodeLabel: this.nodeLabel, data: this.$data })
+      console.log('[D3NodeForm] updateNode clicked', {
+        nodeId: this.nodeId,
+        nodeLabel: this.nodeLabel,
+        data: this.$data
+      })
       mod.updateNode(this.$data, this.nodeId)
       this.close()
     },
     keyPress(event) {
       this.hints = D3Util.formHints(event, this)
     },
-    addNode () {
+    onKeydown(event) {
+      if (Shortcuts.matches(event, 'close')) {
+        event.preventDefault()
+        this.close()
+        return
+      }
+      if (Shortcuts.matches(event, 'clear')) {
+        event.preventDefault()
+        this.nodeLabel = ''
+      }
+    },
+    onKeyup(event) {
+      if (event.repeat) return
+      if (Shortcuts.matches(event, 'save')) {
+        event.preventDefault()
+        this.updateNode()
+      }
+    },
+    addNode() {
       const mod = this.modifier?.value ?? this.modifier
       mod.addNode(this.$data)
       this.common()
     },
-    close () {
+    close() {
       this.common()
     },
     common() {
@@ -547,9 +618,9 @@ export default {
       handler() {
         this._populate()
       },
-      immediate: true,
-    },
-  },
+      immediate: true
+    }
+  }
 }
 </script>
 

--- a/src/components/DiagramForm.vue
+++ b/src/components/DiagramForm.vue
@@ -1,30 +1,12 @@
 <template>
   <Teleport to="body">
     <transition name="fx-scrim">
-      <div
-        v-if="diagramModal"
-        class="fx-scrim"
-        @click="close()"
-      ></div>
+      <div v-if="diagramModal" class="fx-scrim" @click="close()"></div>
     </transition>
     <transition name="fx-dialog">
-      <div
-        v-if="diagramModal"
-        class="fx-dialog-stage"
-      >
-        <focus-trap
-          v-model:active="diagramModal"
-          class="trap is-active"
-        >
-          <div
-            tabindex="0"
-            class="fx-dialog"
-            @keydown.esc="close()"
-            @keyup.alt.s="saveAction()"
-            @keyup.meta.s="saveAction()"
-            @keyup.ctrl.c="close()"
-            @keyup.meta.c="close()"
-          >
+      <div v-if="diagramModal" class="fx-dialog-stage">
+        <focus-trap v-model:active="diagramModal" class="trap is-active">
+          <div tabindex="0" class="fx-dialog" @keydown="onKeydown($event)" @keyup="onKeyup($event)">
             <div class="fx-panel-inner">
               <header class="fx-panel-header">
                 <div class="fx-panel-title">
@@ -38,7 +20,9 @@
                   class="fx-close"
                   aria-label="Close diagram form"
                   @click="close()"
-                >✕</button>
+                >
+                  ✕
+                </button>
               </header>
 
               <div class="fx-readout">
@@ -64,7 +48,12 @@
                   </label>
                   <label class="fx-field">
                     <span class="fx-label">Diagram Name</span>
-                    <input class="fx-input" type="text" v-model="name" placeholder="Name this diagram" />
+                    <input
+                      class="fx-input"
+                      type="text"
+                      v-model="name"
+                      placeholder="Name this diagram"
+                    />
                   </label>
                 </div>
 
@@ -86,7 +75,9 @@
                       class="fx-select-trigger"
                       @click.stop="toggleSel('layout')"
                       @keydown.down.prevent="openAndFocus('layout', $event)"
-                    >{{ layoutLabel }}<span class="fx-caret">▾</span></button>
+                    >
+                      {{ layoutLabel }}<span class="fx-caret">▾</span>
+                    </button>
                     <transition name="fx-drop">
                       <ul v-if="openSel === 'layout'" class="fx-options">
                         <li
@@ -103,7 +94,9 @@
                           @keydown.k.prevent="focusPrev($event)"
                           @keydown.j.prevent="focusNext($event)"
                           @keydown.esc.stop="closeSel($event)"
-                        >{{ opt.label }}</li>
+                        >
+                          {{ opt.label }}
+                        </li>
                       </ul>
                     </transition>
                   </div>
@@ -132,7 +125,9 @@
                           @click.stop="toggleSel('flow')"
                           @keypress.stop=""
                           @keydown.down.prevent="openAndFocus('flow', $event)"
-                        >{{ flowLabel }}<span class="fx-caret">▾</span></button>
+                        >
+                          {{ flowLabel }}<span class="fx-caret">▾</span>
+                        </button>
                         <transition name="fx-drop">
                           <ul v-if="openSel === 'flow'" class="fx-options">
                             <li
@@ -149,7 +144,9 @@
                               @keydown.k.prevent="focusPrev($event)"
                               @keydown.j.prevent="focusNext($event)"
                               @keydown.esc.stop="closeSel($event)"
-                            >{{ opt.label }}</li>
+                            >
+                              {{ opt.label }}
+                            </li>
                           </ul>
                         </transition>
                       </div>
@@ -200,7 +197,12 @@
                   <div class="fx-grid">
                     <label class="fx-field">
                       <span class="fx-label">Spacing Factor</span>
-                      <input class="fx-input" type="number" step="0.1" v-model="breadthfirstOpts.spacingFactor" />
+                      <input
+                        class="fx-input"
+                        type="number"
+                        step="0.1"
+                        v-model="breadthfirstOpts.spacingFactor"
+                      />
                     </label>
                     <div class="fx-field">
                       <span class="fx-label">Options</span>
@@ -221,7 +223,12 @@
                   <div class="fx-grid">
                     <label class="fx-field">
                       <span class="fx-label">Spacing Factor</span>
-                      <input class="fx-input" type="number" step="0.1" v-model="gridOpts.spacingFactor" />
+                      <input
+                        class="fx-input"
+                        type="number"
+                        step="0.1"
+                        v-model="gridOpts.spacingFactor"
+                      />
                     </label>
                     <div class="fx-field">
                       <span class="fx-label">Options</span>
@@ -234,11 +241,21 @@
                   <div class="fx-grid">
                     <label class="fx-field">
                       <span class="fx-label">Rows <em class="fx-opt">optional</em></span>
-                      <input class="fx-input" type="number" v-model="gridOpts.rows" placeholder="auto" />
+                      <input
+                        class="fx-input"
+                        type="number"
+                        v-model="gridOpts.rows"
+                        placeholder="auto"
+                      />
                     </label>
                     <label class="fx-field">
                       <span class="fx-label">Cols <em class="fx-opt">optional</em></span>
-                      <input class="fx-input" type="number" v-model="gridOpts.cols" placeholder="auto" />
+                      <input
+                        class="fx-input"
+                        type="number"
+                        v-model="gridOpts.cols"
+                        placeholder="auto"
+                      />
                     </label>
                   </div>
                 </template>
@@ -248,7 +265,12 @@
                   <div class="fx-grid">
                     <label class="fx-field">
                       <span class="fx-label">Spacing Factor</span>
-                      <input class="fx-input" type="number" step="0.1" v-model="circleOpts.spacingFactor" />
+                      <input
+                        class="fx-input"
+                        type="number"
+                        step="0.1"
+                        v-model="circleOpts.spacingFactor"
+                      />
                     </label>
                     <div class="fx-field">
                       <span class="fx-label">Options</span>
@@ -265,11 +287,20 @@
                   <div class="fx-grid">
                     <label class="fx-field">
                       <span class="fx-label">Spacing Factor</span>
-                      <input class="fx-input" type="number" step="0.1" v-model="concentricOpts.spacingFactor" />
+                      <input
+                        class="fx-input"
+                        type="number"
+                        step="0.1"
+                        v-model="concentricOpts.spacingFactor"
+                      />
                     </label>
                     <label class="fx-field">
                       <span class="fx-label">Min Node Spacing</span>
-                      <input class="fx-input" type="number" v-model="concentricOpts.minNodeSpacing" />
+                      <input
+                        class="fx-input"
+                        type="number"
+                        v-model="concentricOpts.minNodeSpacing"
+                      />
                     </label>
                   </div>
                   <div class="fx-grid">
@@ -298,7 +329,9 @@
                           class="fx-select-trigger"
                           @click.stop="toggleSel('dagreRankDir')"
                           @keydown.down.prevent="openAndFocus('dagreRankDir', $event)"
-                        >{{ dagreRankDirLabel }}<span class="fx-caret">▾</span></button>
+                        >
+                          {{ dagreRankDirLabel }}<span class="fx-caret">▾</span>
+                        </button>
                         <transition name="fx-drop">
                           <ul v-if="openSel === 'dagreRankDir'" class="fx-options">
                             <li
@@ -315,7 +348,9 @@
                               @keydown.k.prevent="focusPrev($event)"
                               @keydown.j.prevent="focusNext($event)"
                               @keydown.esc.stop="closeSel($event)"
-                            >{{ opt.label }}</li>
+                            >
+                              {{ opt.label }}
+                            </li>
                           </ul>
                         </transition>
                       </div>
@@ -328,7 +363,9 @@
                           class="fx-select-trigger"
                           @click.stop="toggleSel('dagreRanker')"
                           @keydown.down.prevent="openAndFocus('dagreRanker', $event)"
-                        >{{ dagreOpts.ranker }}<span class="fx-caret">▾</span></button>
+                        >
+                          {{ dagreOpts.ranker }}<span class="fx-caret">▾</span>
+                        </button>
                         <transition name="fx-drop">
                           <ul v-if="openSel === 'dagreRanker'" class="fx-options">
                             <li
@@ -345,7 +382,9 @@
                               @keydown.k.prevent="focusPrev($event)"
                               @keydown.j.prevent="focusNext($event)"
                               @keydown.esc.stop="closeSel($event)"
-                            >{{ opt.label }}</li>
+                            >
+                              {{ opt.label }}
+                            </li>
                           </ul>
                         </transition>
                       </div>
@@ -386,18 +425,15 @@
                   type="button"
                   class="fx-btn fx-btn-primary"
                   @click="updateLocalDiagram()"
-                >Update <span class="fx-kbd">{{ shortcutLabels.save }}</span></button>
-                <button
-                  v-else
-                  type="button"
-                  class="fx-btn fx-btn-primary"
-                  @click="create()"
-                >Create <span class="fx-kbd">{{ shortcutLabels.save }}</span></button>
-                <button
-                  type="button"
-                  class="fx-btn fx-btn-ghost"
-                  @click="close()"
-                >Cancel <span class="fx-kbd">{{ shortcutLabels.close }}</span></button>
+                >
+                  Update <span class="fx-kbd">{{ shortcutLabels.save }}</span>
+                </button>
+                <button v-else type="button" class="fx-btn fx-btn-primary" @click="create()">
+                  Create <span class="fx-kbd">{{ shortcutLabels.save }}</span>
+                </button>
+                <button type="button" class="fx-btn fx-btn-ghost" @click="close()">
+                  Cancel <span class="fx-kbd">{{ shortcutLabels.close }}</span>
+                </button>
               </footer>
             </div>
           </div>
@@ -410,6 +446,7 @@
 <script>
 import { markRaw } from 'vue'
 import D3Util from '@/helpers/D3Util.js'
+import Shortcuts from '@/helpers/Shortcuts.js'
 import GraphModel from '@/helpers/GraphModel.js'
 import DiagramGraph from '@/helpers/DiagramGraph.js'
 import { modelToGraphlib, graphlibToModel, isGraphlibFormat } from '@/helpers/graphlibMigration.js'
@@ -421,42 +458,42 @@ export default {
   inject: ['modifier'],
   data() {
     return {
-      id:          null,
-      diagram:     null,
-      username:    '',
-      created:     null,
-      name:        'New diagram default name',
+      id: null,
+      diagram: null,
+      username: '',
+      created: null,
+      name: 'New diagram default name',
       description: 'New diagram default description',
       diagramModal: false,
-      update:      null,
-      layoutMode:       'cola',
-      colaOpts:         this.defaultColaOpts(),
+      update: null,
+      layoutMode: 'cola',
+      colaOpts: this.defaultColaOpts(),
       colaConstraintsText: '[]',
-      colaConstraints:  [],
-      coseOpts:         this.defaultCoseOpts(),
+      colaConstraints: [],
+      coseOpts: this.defaultCoseOpts(),
       breadthfirstOpts: this.defaultBreadthfirstOpts(),
-      gridOpts:         this.defaultGridOpts(),
-      circleOpts:       this.defaultCircleOpts(),
-      concentricOpts:   this.defaultConcentricOpts(),
-      dagreOpts:        this.defaultDagreOpts(),
+      gridOpts: this.defaultGridOpts(),
+      circleOpts: this.defaultCircleOpts(),
+      concentricOpts: this.defaultConcentricOpts(),
+      dagreOpts: this.defaultDagreOpts(),
       jsonDiagram: null,
-      openSel:     null,
+      openSel: null,
       flowOptions: [
-        { label: 'None',            value: null },
-        { label: 'Horizontal (x)',  value: 'x' },
-        { label: 'Vertical (y)',    value: 'y' },
+        { label: 'None', value: null },
+        { label: 'Horizontal (x)', value: 'x' },
+        { label: 'Vertical (y)', value: 'y' }
       ],
       dagreRankDirOptions: [
         { label: 'Top → Bottom', value: 'TB' },
         { label: 'Bottom → Top', value: 'BT' },
         { label: 'Left → Right', value: 'LR' },
-        { label: 'Right → Left', value: 'RL' },
+        { label: 'Right → Left', value: 'RL' }
       ],
       dagreRankerOptions: [
         { label: 'Network Simplex', value: 'network-simplex' },
-        { label: 'Tight Tree',      value: 'tight-tree' },
-        { label: 'Longest Path',    value: 'longest-path' },
-      ],
+        { label: 'Tight Tree', value: 'tight-tree' },
+        { label: 'Longest Path', value: 'longest-path' }
+      ]
     }
   },
   computed: {
@@ -464,20 +501,20 @@ export default {
       return D3Util.shortcutLabels()
     },
     flowLabel() {
-      const opt = this.flowOptions.find(o => o.value === this.colaOpts.flow)
+      const opt = this.flowOptions.find((o) => o.value === this.colaOpts.flow)
       return opt ? opt.label : 'None'
     },
     layoutOptions() {
       return D3Util.layoutOptions()
     },
     layoutLabel() {
-      const opt = this.layoutOptions.find(o => o.value === this.layoutMode)
+      const opt = this.layoutOptions.find((o) => o.value === this.layoutMode)
       return opt ? opt.label : this.layoutMode
     },
     dagreRankDirLabel() {
-      const opt = this.dagreRankDirOptions.find(o => o.value === this.dagreOpts.rankDir)
+      const opt = this.dagreRankDirOptions.find((o) => o.value === this.dagreOpts.rankDir)
       return opt ? opt.label : this.dagreOpts.rankDir
-    },
+    }
   },
   mounted() {
     document.addEventListener('click', this.onDocClick)
@@ -487,7 +524,7 @@ export default {
       const mod = this._mod()
       if (mod?.d3dInfo?.id) {
         if (D3Util.auth()) this.updateServerDiagram()
-        else               this.updateLocalDiagram()
+        else this.updateLocalDiagram()
       } else {
         this.diagramModal = true
       }
@@ -495,7 +532,7 @@ export default {
 
     this.emitter.on('editDiagram', () => {
       this.diagramModal = true
-      this.update       = this.diagramModal
+      this.update = this.diagramModal
       this.setDiagramInfo()
     })
 
@@ -508,6 +545,21 @@ export default {
   methods: {
     _mod() {
       return this.modifier?.value ?? this.modifier
+    },
+
+    onKeydown(event) {
+      if (Shortcuts.matches(event, 'close')) {
+        event.preventDefault()
+        this.close()
+      }
+    },
+
+    onKeyup(event) {
+      if (event.repeat) return
+      if (Shortcuts.matches(event, 'save')) {
+        event.preventDefault()
+        this.saveAction()
+      }
     },
 
     toggleSel(key) {
@@ -575,31 +627,31 @@ export default {
     defaultColaOpts() {
       const d = D3Util.appDefaults()
       return {
-        edgeLength:        d.defaultColaEdgeLength,
-        nodeSpacing:       d.defaultColaNodeSpacing,
-        flow:              d.defaultColaFlow,
-        avoidOverlap:      d.defaultColaAvoidOverlap,
+        edgeLength: d.defaultColaEdgeLength,
+        nodeSpacing: d.defaultColaNodeSpacing,
+        flow: d.defaultColaFlow,
+        avoidOverlap: d.defaultColaAvoidOverlap,
         maxSimulationTime: d.defaultColaMaxSimulationTime,
-        gravity:           d.defaultColaGravity,
+        gravity: d.defaultColaGravity
       }
     },
 
     defaultCoseOpts() {
       const d = D3Util.appDefaults()
       return {
-        nodeRepulsion:   d.defaultCoseNodeRepulsion,
+        nodeRepulsion: d.defaultCoseNodeRepulsion,
         idealEdgeLength: d.defaultCoseIdealEdgeLength,
-        gravity:         d.defaultCoseGravity,
-        nodeOverlap:     d.defaultCoseNodeOverlap,
+        gravity: d.defaultCoseGravity,
+        nodeOverlap: d.defaultCoseNodeOverlap
       }
     },
 
     defaultBreadthfirstOpts() {
       const d = D3Util.appDefaults()
       return {
-        directed:      d.defaultBreadthfirstDirected,
-        circle:        d.defaultBreadthfirstCircle,
-        spacingFactor: d.defaultBreadthfirstSpacingFactor,
+        directed: d.defaultBreadthfirstDirected,
+        circle: d.defaultBreadthfirstCircle,
+        spacingFactor: d.defaultBreadthfirstSpacingFactor
       }
     },
 
@@ -607,9 +659,9 @@ export default {
       const d = D3Util.appDefaults()
       return {
         spacingFactor: d.defaultGridSpacingFactor,
-        avoidOverlap:  d.defaultGridAvoidOverlap,
-        rows:          d.defaultGridRows,
-        cols:          d.defaultGridCols,
+        avoidOverlap: d.defaultGridAvoidOverlap,
+        rows: d.defaultGridRows,
+        cols: d.defaultGridCols
       }
     },
 
@@ -617,17 +669,17 @@ export default {
       const d = D3Util.appDefaults()
       return {
         spacingFactor: d.defaultCircleSpacingFactor,
-        clockwise:     d.defaultCircleClockwise,
+        clockwise: d.defaultCircleClockwise
       }
     },
 
     defaultConcentricOpts() {
       const d = D3Util.appDefaults()
       return {
-        spacingFactor:  d.defaultConcentricSpacingFactor,
+        spacingFactor: d.defaultConcentricSpacingFactor,
         minNodeSpacing: d.defaultConcentricMinNodeSpacing,
-        clockwise:      d.defaultConcentricClockwise,
-        equidistant:    d.defaultConcentricEquidistant,
+        clockwise: d.defaultConcentricClockwise,
+        equidistant: d.defaultConcentricEquidistant
       }
     },
 
@@ -638,7 +690,7 @@ export default {
         nodeSep: d.defaultDagreNodeSep,
         rankSep: d.defaultDagreRankSep,
         edgeSep: d.defaultDagreEdgeSep,
-        ranker:  d.defaultDagreRanker,
+        ranker: d.defaultDagreRanker
       }
     },
 
@@ -651,98 +703,184 @@ export default {
       this.layoutMode = settings.defaultLayoutMode || defaults.defaultLayoutMode
 
       this.colaOpts = {
-        edgeLength:        settings.defaultColaEdgeLength        !== undefined ? Number(settings.defaultColaEdgeLength)        : defaults.defaultColaEdgeLength,
-        nodeSpacing:       settings.defaultColaNodeSpacing       !== undefined ? Number(settings.defaultColaNodeSpacing)       : defaults.defaultColaNodeSpacing,
-        flow:              settings.defaultColaFlow              !== undefined ? settings.defaultColaFlow                      : defaults.defaultColaFlow,
-        avoidOverlap:      settings.defaultColaAvoidOverlap      !== undefined ? Boolean(settings.defaultColaAvoidOverlap)     : defaults.defaultColaAvoidOverlap,
-        maxSimulationTime: settings.defaultColaMaxSimulationTime !== undefined ? Number(settings.defaultColaMaxSimulationTime) : defaults.defaultColaMaxSimulationTime,
-        gravity:           settings.defaultColaGravity           !== undefined ? Number(settings.defaultColaGravity)           : defaults.defaultColaGravity,
+        edgeLength:
+          settings.defaultColaEdgeLength !== undefined
+            ? Number(settings.defaultColaEdgeLength)
+            : defaults.defaultColaEdgeLength,
+        nodeSpacing:
+          settings.defaultColaNodeSpacing !== undefined
+            ? Number(settings.defaultColaNodeSpacing)
+            : defaults.defaultColaNodeSpacing,
+        flow:
+          settings.defaultColaFlow !== undefined
+            ? settings.defaultColaFlow
+            : defaults.defaultColaFlow,
+        avoidOverlap:
+          settings.defaultColaAvoidOverlap !== undefined
+            ? Boolean(settings.defaultColaAvoidOverlap)
+            : defaults.defaultColaAvoidOverlap,
+        maxSimulationTime:
+          settings.defaultColaMaxSimulationTime !== undefined
+            ? Number(settings.defaultColaMaxSimulationTime)
+            : defaults.defaultColaMaxSimulationTime,
+        gravity:
+          settings.defaultColaGravity !== undefined
+            ? Number(settings.defaultColaGravity)
+            : defaults.defaultColaGravity
       }
       this.colaConstraintsText = '[]'
       this.colaConstraints = []
 
       this.coseOpts = {
-        nodeRepulsion:   settings.defaultCoseNodeRepulsion   !== undefined ? Number(settings.defaultCoseNodeRepulsion)   : defaults.defaultCoseNodeRepulsion,
-        idealEdgeLength: settings.defaultCoseIdealEdgeLength !== undefined ? Number(settings.defaultCoseIdealEdgeLength) : defaults.defaultCoseIdealEdgeLength,
-        gravity:         settings.defaultCoseGravity         !== undefined ? Number(settings.defaultCoseGravity)         : defaults.defaultCoseGravity,
-        nodeOverlap:     settings.defaultCoseNodeOverlap     !== undefined ? Number(settings.defaultCoseNodeOverlap)     : defaults.defaultCoseNodeOverlap,
+        nodeRepulsion:
+          settings.defaultCoseNodeRepulsion !== undefined
+            ? Number(settings.defaultCoseNodeRepulsion)
+            : defaults.defaultCoseNodeRepulsion,
+        idealEdgeLength:
+          settings.defaultCoseIdealEdgeLength !== undefined
+            ? Number(settings.defaultCoseIdealEdgeLength)
+            : defaults.defaultCoseIdealEdgeLength,
+        gravity:
+          settings.defaultCoseGravity !== undefined
+            ? Number(settings.defaultCoseGravity)
+            : defaults.defaultCoseGravity,
+        nodeOverlap:
+          settings.defaultCoseNodeOverlap !== undefined
+            ? Number(settings.defaultCoseNodeOverlap)
+            : defaults.defaultCoseNodeOverlap
       }
       this.breadthfirstOpts = {
-        directed:      settings.defaultBreadthfirstDirected      !== undefined ? Boolean(settings.defaultBreadthfirstDirected)      : defaults.defaultBreadthfirstDirected,
-        circle:        settings.defaultBreadthfirstCircle        !== undefined ? Boolean(settings.defaultBreadthfirstCircle)        : defaults.defaultBreadthfirstCircle,
-        spacingFactor: settings.defaultBreadthfirstSpacingFactor !== undefined ? Number(settings.defaultBreadthfirstSpacingFactor) : defaults.defaultBreadthfirstSpacingFactor,
+        directed:
+          settings.defaultBreadthfirstDirected !== undefined
+            ? Boolean(settings.defaultBreadthfirstDirected)
+            : defaults.defaultBreadthfirstDirected,
+        circle:
+          settings.defaultBreadthfirstCircle !== undefined
+            ? Boolean(settings.defaultBreadthfirstCircle)
+            : defaults.defaultBreadthfirstCircle,
+        spacingFactor:
+          settings.defaultBreadthfirstSpacingFactor !== undefined
+            ? Number(settings.defaultBreadthfirstSpacingFactor)
+            : defaults.defaultBreadthfirstSpacingFactor
       }
       this.gridOpts = {
-        spacingFactor: settings.defaultGridSpacingFactor !== undefined ? Number(settings.defaultGridSpacingFactor) : defaults.defaultGridSpacingFactor,
-        avoidOverlap:  settings.defaultGridAvoidOverlap  !== undefined ? Boolean(settings.defaultGridAvoidOverlap) : defaults.defaultGridAvoidOverlap,
-        rows:          settings.defaultGridRows          !== undefined ? settings.defaultGridRows                   : defaults.defaultGridRows,
-        cols:          settings.defaultGridCols          !== undefined ? settings.defaultGridCols                   : defaults.defaultGridCols,
+        spacingFactor:
+          settings.defaultGridSpacingFactor !== undefined
+            ? Number(settings.defaultGridSpacingFactor)
+            : defaults.defaultGridSpacingFactor,
+        avoidOverlap:
+          settings.defaultGridAvoidOverlap !== undefined
+            ? Boolean(settings.defaultGridAvoidOverlap)
+            : defaults.defaultGridAvoidOverlap,
+        rows:
+          settings.defaultGridRows !== undefined
+            ? settings.defaultGridRows
+            : defaults.defaultGridRows,
+        cols:
+          settings.defaultGridCols !== undefined
+            ? settings.defaultGridCols
+            : defaults.defaultGridCols
       }
       this.circleOpts = {
-        spacingFactor: settings.defaultCircleSpacingFactor !== undefined ? Number(settings.defaultCircleSpacingFactor) : defaults.defaultCircleSpacingFactor,
-        clockwise:     settings.defaultCircleClockwise     !== undefined ? Boolean(settings.defaultCircleClockwise)    : defaults.defaultCircleClockwise,
+        spacingFactor:
+          settings.defaultCircleSpacingFactor !== undefined
+            ? Number(settings.defaultCircleSpacingFactor)
+            : defaults.defaultCircleSpacingFactor,
+        clockwise:
+          settings.defaultCircleClockwise !== undefined
+            ? Boolean(settings.defaultCircleClockwise)
+            : defaults.defaultCircleClockwise
       }
       this.concentricOpts = {
-        spacingFactor:  settings.defaultConcentricSpacingFactor  !== undefined ? Number(settings.defaultConcentricSpacingFactor)  : defaults.defaultConcentricSpacingFactor,
-        minNodeSpacing: settings.defaultConcentricMinNodeSpacing !== undefined ? Number(settings.defaultConcentricMinNodeSpacing) : defaults.defaultConcentricMinNodeSpacing,
-        clockwise:      settings.defaultConcentricClockwise      !== undefined ? Boolean(settings.defaultConcentricClockwise)     : defaults.defaultConcentricClockwise,
-        equidistant:    settings.defaultConcentricEquidistant    !== undefined ? Boolean(settings.defaultConcentricEquidistant)   : defaults.defaultConcentricEquidistant,
+        spacingFactor:
+          settings.defaultConcentricSpacingFactor !== undefined
+            ? Number(settings.defaultConcentricSpacingFactor)
+            : defaults.defaultConcentricSpacingFactor,
+        minNodeSpacing:
+          settings.defaultConcentricMinNodeSpacing !== undefined
+            ? Number(settings.defaultConcentricMinNodeSpacing)
+            : defaults.defaultConcentricMinNodeSpacing,
+        clockwise:
+          settings.defaultConcentricClockwise !== undefined
+            ? Boolean(settings.defaultConcentricClockwise)
+            : defaults.defaultConcentricClockwise,
+        equidistant:
+          settings.defaultConcentricEquidistant !== undefined
+            ? Boolean(settings.defaultConcentricEquidistant)
+            : defaults.defaultConcentricEquidistant
       }
       this.dagreOpts = {
-        rankDir: settings.defaultDagreRankDir !== undefined ? settings.defaultDagreRankDir          : defaults.defaultDagreRankDir,
-        nodeSep: settings.defaultDagreNodeSep !== undefined ? Number(settings.defaultDagreNodeSep)  : defaults.defaultDagreNodeSep,
-        rankSep: settings.defaultDagreRankSep !== undefined ? Number(settings.defaultDagreRankSep)  : defaults.defaultDagreRankSep,
-        edgeSep: settings.defaultDagreEdgeSep !== undefined ? Number(settings.defaultDagreEdgeSep)  : defaults.defaultDagreEdgeSep,
-        ranker:  settings.defaultDagreRanker  !== undefined ? settings.defaultDagreRanker           : defaults.defaultDagreRanker,
+        rankDir:
+          settings.defaultDagreRankDir !== undefined
+            ? settings.defaultDagreRankDir
+            : defaults.defaultDagreRankDir,
+        nodeSep:
+          settings.defaultDagreNodeSep !== undefined
+            ? Number(settings.defaultDagreNodeSep)
+            : defaults.defaultDagreNodeSep,
+        rankSep:
+          settings.defaultDagreRankSep !== undefined
+            ? Number(settings.defaultDagreRankSep)
+            : defaults.defaultDagreRankSep,
+        edgeSep:
+          settings.defaultDagreEdgeSep !== undefined
+            ? Number(settings.defaultDagreEdgeSep)
+            : defaults.defaultDagreEdgeSep,
+        ranker:
+          settings.defaultDagreRanker !== undefined
+            ? settings.defaultDagreRanker
+            : defaults.defaultDagreRanker
       }
 
-      const model = markRaw(new GraphModel([
-        { group: 'nodes', data: { id: 'first', label: 'first node', shape: 'rectangle' } }
-      ]))
+      const model = markRaw(
+        new GraphModel([
+          { group: 'nodes', data: { id: 'first', label: 'first node', shape: 'rectangle' } }
+        ])
+      )
       model.colaConstraints = this.colaConstraints
 
       const d3dInfo = {
-        id:          null,
-        diagram:     model,
-        name:        D3Util.tempInfo().name,
+        id: null,
+        diagram: model,
+        name: D3Util.tempInfo().name,
         description: D3Util.tempInfo().description,
-        layoutMode:       this.layoutMode,
-        colaOpts:         { ...this.colaOpts },
-        colaConstraints:  this.colaConstraints,
-        coseOpts:         { ...this.coseOpts },
+        layoutMode: this.layoutMode,
+        colaOpts: { ...this.colaOpts },
+        colaConstraints: this.colaConstraints,
+        coseOpts: { ...this.coseOpts },
         breadthfirstOpts: { ...this.breadthfirstOpts },
-        gridOpts:         { ...this.gridOpts },
-        circleOpts:       { ...this.circleOpts },
-        concentricOpts:   { ...this.concentricOpts },
-        dagreOpts:        { ...this.dagreOpts },
+        gridOpts: { ...this.gridOpts },
+        circleOpts: { ...this.circleOpts },
+        concentricOpts: { ...this.concentricOpts },
+        dagreOpts: { ...this.dagreOpts }
       }
 
       this._newModifier(d3dInfo)
     },
 
     setDiagramInfo(newDiagram) {
-      const mod  = this._mod()
+      const mod = this._mod()
       const info = mod?.d3dInfo || {}
 
-      this.id          = newDiagram ? this.id          : info.id
-      this.name        = newDiagram ? this.name        : info.name
+      this.id = newDiagram ? this.id : info.id
+      this.name = newDiagram ? this.name : info.name
       this.description = newDiagram ? this.description : info.description
-      this.diagram     = newDiagram ? this.diagram     : info.diagram
-      this.created     = newDiagram ? this.created     : info.created
+      this.diagram = newDiagram ? this.diagram : info.diagram
+      this.created = newDiagram ? this.created : info.created
 
       if (this.diagram) {
-        const json       = modelToGraphlib(this.diagram)
+        const json = modelToGraphlib(this.diagram)
         this.jsonDiagram = JSON.stringify(json, null, 2)
       }
 
       this.layoutMode = mod?.layoutMode || 'cola'
-      if (mod?.colaOpts)        this.colaOpts        = { ...mod.colaOpts }
-      if (mod?.coseOpts)        this.coseOpts        = { ...mod.coseOpts }
+      if (mod?.colaOpts) this.colaOpts = { ...mod.colaOpts }
+      if (mod?.coseOpts) this.coseOpts = { ...mod.coseOpts }
       if (mod?.breadthfirstOpts) this.breadthfirstOpts = { ...mod.breadthfirstOpts }
-      if (mod?.gridOpts)        this.gridOpts        = { ...mod.gridOpts }
-      if (mod?.circleOpts)      this.circleOpts      = { ...mod.circleOpts }
-      if (mod?.concentricOpts)  this.concentricOpts  = { ...mod.concentricOpts }
-      if (mod?.dagreOpts)       this.dagreOpts       = { ...mod.dagreOpts }
+      if (mod?.gridOpts) this.gridOpts = { ...mod.gridOpts }
+      if (mod?.circleOpts) this.circleOpts = { ...mod.circleOpts }
+      if (mod?.concentricOpts) this.concentricOpts = { ...mod.concentricOpts }
+      if (mod?.dagreOpts) this.dagreOpts = { ...mod.dagreOpts }
 
       const constraints = mod?.cy?.colaConstraints ?? mod?.colaConstraints ?? []
       this.colaConstraints = Array.isArray(constraints) ? constraints : []
@@ -763,13 +901,13 @@ export default {
       this.setDiagramInfo(true)
       this._applyLayoutOptions()
 
-      const json    = modelToGraphlib(this.diagram)
+      const json = modelToGraphlib(this.diagram)
       const payload = {
-        name:        this.name,
+        name: this.name,
         description: this.description,
-        diagram:     JSON.stringify(json),
-        created:     this.created,
-        updated:     new Date().toISOString(),
+        diagram: JSON.stringify(json),
+        created: this.created,
+        updated: new Date().toISOString()
       }
 
       if (D3Util.auth()) {
@@ -783,9 +921,16 @@ export default {
           this.emitter.emit('appMessage', { message: 'Failed to create diagram', result })
         }
       } else {
-        const id = D3Util.createLocalEntry({ name: this.name, description: this.description, diagram: this.diagram })
-        this.id  = id
-        this.emitter.emit('appMessage', { message: 'Changes saved to local storage', status: 'info' })
+        const id = D3Util.createLocalEntry({
+          name: this.name,
+          description: this.description,
+          diagram: this.diagram
+        })
+        this.id = id
+        this.emitter.emit('appMessage', {
+          message: 'Changes saved to local storage',
+          status: 'info'
+        })
         this.emitter.emit('updateDiagramInfo', this)
       }
 
@@ -795,14 +940,14 @@ export default {
     _applyLayoutOptions() {
       const mod = this._mod()
       if (mod) {
-        mod.layoutMode       = this.layoutMode
-        mod.colaOpts         = { ...this.colaOpts }
-        mod.coseOpts         = { ...this.coseOpts }
+        mod.layoutMode = this.layoutMode
+        mod.colaOpts = { ...this.colaOpts }
+        mod.coseOpts = { ...this.coseOpts }
         mod.breadthfirstOpts = { ...this.breadthfirstOpts }
-        mod.gridOpts         = { ...this.gridOpts }
-        mod.circleOpts       = { ...this.circleOpts }
-        mod.concentricOpts   = { ...this.concentricOpts }
-        mod.dagreOpts        = { ...this.dagreOpts }
+        mod.gridOpts = { ...this.gridOpts }
+        mod.circleOpts = { ...this.circleOpts }
+        mod.concentricOpts = { ...this.concentricOpts }
+        mod.dagreOpts = { ...this.dagreOpts }
         const constraints = this._parseConstraints()
         if (constraints !== null) {
           this.colaConstraints = constraints
@@ -815,19 +960,19 @@ export default {
 
     updateLocalDiagram() {
       const d3dInfo = {
-        id:          this.id,
-        name:        this.name,
+        id: this.id,
+        name: this.name,
         description: this.description,
-        created:     this.created,
-        layoutMode:       this.layoutMode,
-        colaOpts:         { ...this.colaOpts },
-        colaConstraints:  this.colaConstraints,
-        coseOpts:         { ...this.coseOpts },
+        created: this.created,
+        layoutMode: this.layoutMode,
+        colaOpts: { ...this.colaOpts },
+        colaConstraints: this.colaConstraints,
+        coseOpts: { ...this.coseOpts },
         breadthfirstOpts: { ...this.breadthfirstOpts },
-        gridOpts:         { ...this.gridOpts },
-        circleOpts:       { ...this.circleOpts },
-        concentricOpts:   { ...this.concentricOpts },
-        dagreOpts:        { ...this.dagreOpts },
+        gridOpts: { ...this.gridOpts },
+        circleOpts: { ...this.circleOpts },
+        concentricOpts: { ...this.concentricOpts },
+        dagreOpts: { ...this.dagreOpts }
       }
 
       const model = this._modelFromJson()
@@ -837,30 +982,30 @@ export default {
       this._newModifier(d3dInfo)
 
       D3Util.updateLocalEntry({
-        id:          this.id,
-        name:        this.name,
+        id: this.id,
+        name: this.name,
         description: this.description,
-        diagram:     this.diagram,
-        created:     this.created,
+        diagram: this.diagram,
+        created: this.created
       })
       this.close()
     },
 
     async updateServerDiagram() {
       const d3dInfo = {
-        id:          this.id,
-        name:        this.name,
+        id: this.id,
+        name: this.name,
         description: this.description,
-        created:     this.created,
-        layoutMode:       this.layoutMode,
-        colaOpts:         { ...this.colaOpts },
-        colaConstraints:  this.colaConstraints,
-        coseOpts:         { ...this.coseOpts },
+        created: this.created,
+        layoutMode: this.layoutMode,
+        colaOpts: { ...this.colaOpts },
+        colaConstraints: this.colaConstraints,
+        coseOpts: { ...this.coseOpts },
         breadthfirstOpts: { ...this.breadthfirstOpts },
-        gridOpts:         { ...this.gridOpts },
-        circleOpts:       { ...this.circleOpts },
-        concentricOpts:   { ...this.concentricOpts },
-        dagreOpts:        { ...this.dagreOpts },
+        gridOpts: { ...this.gridOpts },
+        circleOpts: { ...this.circleOpts },
+        concentricOpts: { ...this.concentricOpts },
+        dagreOpts: { ...this.dagreOpts }
       }
 
       const model = this._modelFromJson()
@@ -869,14 +1014,14 @@ export default {
       d3dInfo.diagram = model
       this._newModifier(d3dInfo)
 
-      const json        = modelToGraphlib(this.diagram)
+      const json = modelToGraphlib(this.diagram)
       const updatedData = {
-        id:          this.id,
-        name:        this.name,
+        id: this.id,
+        name: this.name,
         description: this.description,
-        diagram:     JSON.stringify(json),
-        updated:     new Date().toISOString(),
-        created:     this.created,
+        diagram: JSON.stringify(json),
+        updated: new Date().toISOString(),
+        created: this.created
       }
 
       const response = await D3DApi.updateDiagram(updatedData)
@@ -892,7 +1037,9 @@ export default {
     _modelFromJson() {
       try {
         const parsed = JSON.parse(this.jsonDiagram)
-        const model = markRaw(isGraphlibFormat(parsed) ? graphlibToModel(parsed) : new GraphModel(parsed))
+        const model = markRaw(
+          isGraphlibFormat(parsed) ? graphlibToModel(parsed) : new GraphModel(parsed)
+        )
         model.colaConstraints = this.colaConstraints
         this.diagram = model
         return model
@@ -910,8 +1057,8 @@ export default {
     close() {
       this.diagramModal = false
       this.emitter.emit('changeActive')
-    },
-  },
+    }
+  }
 }
 </script>
 
@@ -925,7 +1072,7 @@ export default {
   font-size: 13px;
   color: rgb(var(--fx-ink));
 }
-.fx-check-row input[type="checkbox"] {
+.fx-check-row input[type='checkbox'] {
   accent-color: rgb(var(--fx-accent));
   width: 14px;
   height: 14px;

--- a/src/components/DiagramGraphView.vue
+++ b/src/components/DiagramGraphView.vue
@@ -89,6 +89,7 @@ import D3NodeForm from '@/components/D3NodeForm.vue'
 import Hints from '@/helpers/Hints.js'
 import AltKeys from '@/helpers/AltKeys.js'
 import OtherKeys from '@/helpers/OtherKeys.js'
+import { resolveGraphKey } from '@/helpers/GraphKeys.js'
 
 export default {
   name: 'DiagramGraphView',
@@ -333,56 +334,105 @@ export default {
           this.hintKeysReplaced = ''
           hints.removeHints(data.hints)
         }
-      } else if (event.altKey === true || event.metaKey === true) {
-        const altKeys = new AltKeys(this.emitter, mod)
-        const reset   = altKeys.key(event.key, this)
-        if (reset) this.resetValues()
       } else {
-        const otherKeys = new OtherKeys(this.emitter, mod, this._onHintBadgeClick)
-        const result    = otherKeys.defaultActions(
-          event.key, this.edgeOrNode, this.focusedNodeId, this.focusedEdgeId
-        )
+        const graph = resolveGraphKey(event, {
+          modifier: mod,
+          edgeOrNode: this.edgeOrNode,
+          focusedNodeId: this.focusedNodeId,
+          focusedEdgeId: this.focusedEdgeId
+        })
 
-        if (D3Util.debug) console.log('keyPress result', result)
+        if (D3Util.debug) console.log('keyPress result', graph)
 
-        if (event.key === 'e') {
-          if (!result) return
-          this.d3Data    = result
-          this.openSheet = true
+        if (!graph) {
+          if (event.altKey === true || event.metaKey === true) {
+            const altKeys = new AltKeys(this.emitter, mod)
+            const reset = altKeys.key(event.key, this)
+            if (reset) this.resetValues()
+          }
+          return
         }
 
-        if (event.key === 'd') {
-          this._clearMultiSelection()
-        }
-
-        if (result) {
-          if (event.key === 'x') {
+        switch (graph.action) {
+          case 'menu':
+            this.emitter.emit('changeActive', 'Menu')
+            break
+          case 'help':
+            this.emitter.emit('showHelp')
+            break
+          case 'actionsMenu':
+            this.emitter.emit('changeActive', 'Actions Menu')
+            break
+          case 'toggleTheme':
+            this.emitter.emit('toggleTheme')
+            break
+          case 'addNode':
+            mod.addNode(D3Util.defaultNodeValues())
+            break
+          case 'addEdge':
+            mod.addEdge(D3Util.defaultEdgeValues())
+            this._clearMultiSelection()
+            break
+          case 'edit':
+            this.d3Data = graph.data
+            this.emitter.emit('changeActive', graph.mode)
+            this.openSheet = true
+            break
+          case 'delete':
             if (this.edgeOrNode === 'nodes') {
               const ok = mod.deleteNode(this.focusedNodeId)
               if (ok) this.focusedNodeId = null
-              else this.emitter.emit('appMessage', { message: 'Unable to delete node', status: 'info' })
+              else
+                this.emitter.emit('appMessage', {
+                  message: 'Unable to delete node',
+                  status: 'info'
+                })
             } else {
               const ok = mod.deleteEdge(this.focusedEdgeId)
               if (ok) this.focusedEdgeId = null
-              else this.emitter.emit('appMessage', { message: 'Unable to delete edge', status: 'info' })
+              else
+                this.emitter.emit('appMessage', {
+                  message: 'Unable to delete edge',
+                  status: 'info'
+                })
             }
-          } else if (event.key === 'f') {
-            this.hints = result.hints
-          } else if (event.key === 'Enter') {
-            this.selectedNodes   = result.selectedNodes
-            this.doubleSelection = result.doubleSelection
-            mod.selectedNodes    = result.selectedNodes
-            mod.doubleSelection  = result.doubleSelection
+            break
+          case 'copy':
+            mod.createCopyV2(this.focusedNodeId)
+            break
+          case 'showHints':
+            this.hints = new OtherKeys(this.emitter, mod, this._onHintBadgeClick).F(this.edgeOrNode)
+            break
+          case 'select': {
+            const sel = new OtherKeys(this.emitter, mod, this._onHintBadgeClick)
+            sel.focusedIndex = this.focusedIndex
+            sel.focusedNodeId = this.focusedNodeId
+            sel.focusedEdgeId = this.focusedEdgeId
+            const selection = sel.enter(this.edgeOrNode)
+            this.selectedNodes = selection.selectedNodes
+            this.doubleSelection = selection.doubleSelection
+            mod.selectedNodes = selection.selectedNodes
+            mod.doubleSelection = selection.doubleSelection
             this._syncSelectionCrosshairs()
-          } else if (event.key === 'Escape') {
+            break
+          }
+          case 'history':
+            if (mod?.d3dInfo?.id) this.showHistory = true
+            break
+          case 'close':
             if (this.escCount >= 2) this.resetValues()
             else this.escCount++
-          } else if (event.key === 'y') {
-            mod.createCopyV2(this.focusedNodeId)
-          } else {
-            if (this.edgeOrNode === 'nodes')      this.focusedNodeId = result.nodesId
-            else if (this.edgeOrNode === 'edges') this.focusedEdgeId = result.edgesId
-            this.focusedIndex = result.index
+            break
+          case 'nav': {
+            const nav = new OtherKeys(this.emitter, mod, this._onHintBadgeClick)
+            nav.focusedIndex = this.focusedIndex
+            nav.focusedNodeId = this.focusedNodeId
+            nav.focusedEdgeId = this.focusedEdgeId
+            const selectedId = nav._navigate(graph.direction, this.edgeOrNode)
+            if (this.edgeOrNode === 'nodes') this.focusedNodeId = selectedId
+            else this.focusedEdgeId = selectedId
+            this.focusedIndex = nav.focusedIndex
+            break
           }
         }
       }

--- a/src/components/Helper.vue
+++ b/src/components/Helper.vue
@@ -78,70 +78,78 @@
 </template>
 <script>
 import D3Util from '@/helpers/D3Util.js'
+import Shortcuts from '@/helpers/Shortcuts.js'
 
 export default {
   name: 'D3DHelper',
   props: ['expand', 'diagramInfo'],
-  data () {
-    return {
-      selectionOptions: [
-        { title: 'Focus Node',  shortcut: 'j or k' },
-        { title: 'Active 1',    shortcut: 'enter' },
-        { title: 'Active 2',    shortcut: 'enter enter' },
-        { title: 'Hints',       shortcut: 'f' },
-        { title: 'Change Focus', shortcut: 'esc' },
-        { title: 'Command Palette', shortcut: '⌘ / Ctrl + k' },
-      ],
-      actions: [
-        { title: 'Delete',      shortcut: 'x' },
-        { title: 'Read Only',   shortcut: 'r' },
-        { title: 'Edit',        shortcut: 'e' },
-        { title: 'Create Node', shortcut: 'n' },
-        { title: 'Create Edge', shortcut: 'd' },
-      ],
-      other: [
-        { title: 'Settings',    shortcut: 'Ctrl + t' },
-        { title: 'Hints',       shortcut: 'f' },
-      ],
-    }
-  },
   computed: {
     mod() {
       return D3Util.isMac() ? '⌘' : 'Alt'
     },
+    other() {
+      return [
+        { title: 'Settings', shortcut: 'Ctrl + t' },
+        { title: 'Hints', shortcut: Shortcuts.label('showHints') }
+      ]
+    },
+    selectionOptions() {
+      return [
+        {
+          title: 'Focus Node',
+          shortcut: `${Shortcuts.label('navDown')} or ${Shortcuts.label('navUp')}`
+        },
+        { title: 'Active 1', shortcut: Shortcuts.label('select') },
+        {
+          title: 'Active 2',
+          shortcut: `${Shortcuts.label('select')} ${Shortcuts.label('select')}`
+        },
+        { title: 'Hints', shortcut: Shortcuts.label('showHints') },
+        { title: 'Change Focus', shortcut: Shortcuts.label('close') },
+        { title: 'Command Palette', shortcut: '⌘ / Ctrl + k' }
+      ]
+    },
+    actions() {
+      return [
+        { title: 'Delete', shortcut: Shortcuts.label('deleteElement') },
+        { title: 'Read Only', shortcut: 'r' },
+        { title: 'Edit', shortcut: Shortcuts.label('editElement') },
+        { title: 'Create Node', shortcut: Shortcuts.label('addNode') },
+        { title: 'Create Edge', shortcut: Shortcuts.label('addEdge') }
+      ]
+    },
     zoom() {
       return [
-        { title: 'Zoom In',   shortcut: `${this.mod} + =` },
-        { title: 'Zoom Out',  shortcut: `${this.mod} + -` },
+        { title: 'Zoom In', shortcut: `${this.mod} + =` },
+        { title: 'Zoom Out', shortcut: `${this.mod} + -` },
         { title: 'Pan Right', shortcut: `${this.mod} + l` },
-        { title: 'Pan Left',  shortcut: `${this.mod} + h` },
-        { title: 'Pan Up',    shortcut: `${this.mod} + k` },
-        { title: 'Pan Down',  shortcut: `${this.mod} + j` },
+        { title: 'Pan Left', shortcut: `${this.mod} + h` },
+        { title: 'Pan Up', shortcut: `${this.mod} + k` },
+        { title: 'Pan Down', shortcut: `${this.mod} + j` }
       ]
     },
     samus() {
       return [
-        { title: 'New Diagram',  shortcut: `${this.mod} + n` },
+        { title: 'New Diagram', shortcut: `${this.mod} + n` },
         { title: 'Open Diagram', shortcut: `${this.mod} + o` },
         { title: 'Edit Diagram', shortcut: `${this.mod} + e` },
-        { title: 'Save Diagram', shortcut: `${this.mod} + s` },
+        { title: 'Save Diagram', shortcut: `${this.mod} + s` }
       ]
     },
     layouts() {
       return [
-        { title: 'Cola (Physics-based)',  shortcut: `${this.mod} + 1` },
+        { title: 'Cola (Physics-based)', shortcut: `${this.mod} + 1` },
         { title: 'CoSE (Force-directed)', shortcut: `${this.mod} + 2` },
-        { title: 'Breadth First (Tree)',  shortcut: `${this.mod} + 3` },
-        { title: 'Grid',                  shortcut: `${this.mod} + 4` },
-        { title: 'Circle',                shortcut: `${this.mod} + 5` },
-        { title: 'Concentric',            shortcut: `${this.mod} + 6` },
-        { title: 'Dagre (Hierarchical)',  shortcut: `${this.mod} + 7` },
-        { title: 'Random',                shortcut: `${this.mod} + 8` },
+        { title: 'Breadth First (Tree)', shortcut: `${this.mod} + 3` },
+        { title: 'Grid', shortcut: `${this.mod} + 4` },
+        { title: 'Circle', shortcut: `${this.mod} + 5` },
+        { title: 'Concentric', shortcut: `${this.mod} + 6` },
+        { title: 'Dagre (Hierarchical)', shortcut: `${this.mod} + 7` },
+        { title: 'Random', shortcut: `${this.mod} + 8` }
       ]
-    },
-  },
+    }
+  }
 }
 </script>
 
-<style scoped>
-</style>
+<style scoped></style>

--- a/src/components/Login.vue
+++ b/src/components/Login.vue
@@ -1,42 +1,21 @@
 <template>
   <Teleport to="body">
     <transition name="fx-scrim">
-      <div
-        v-if="loginModal"
-        class="fx-scrim"
-        @click="common()"
-      ></div>
+      <div v-if="loginModal" class="fx-scrim" @click="common()"></div>
     </transition>
     <transition name="fx-dialog">
-      <div
-        v-if="loginModal"
-        class="fx-dialog-stage"
-      >
-        <focus-trap
-          v-model:active="loginModal"
-          class="trap is-active"
-        >
-          <div
-            tabindex="0"
-            class="fx-dialog"
-            @keydown.esc="common($event)"
-            @keyup.alt.l="login()"
-            @keyup.meta.l="login()"
-            @keyup.ctrl.c="close()"
-            @keyup.meta.c="close()"
-          >
+      <div v-if="loginModal" class="fx-dialog-stage">
+        <focus-trap v-model:active="loginModal" class="trap is-active">
+          <div tabindex="0" class="fx-dialog" @keydown="onKeydown($event)" @keyup="onKeyup($event)">
             <div class="fx-panel-inner">
               <header class="fx-panel-header">
                 <div class="fx-panel-title">
                   <span class="fx-title-chip fx-chip-edit">AUTH</span>
                   <h2 class="fx-title">LOGIN</h2>
                 </div>
-                <button
-                  type="button"
-                  class="fx-close"
-                  aria-label="Close login"
-                  @click="close()"
-                >✕</button>
+                <button type="button" class="fx-close" aria-label="Close login" @click="close()">
+                  ✕
+                </button>
               </header>
 
               <div class="fx-readout">
@@ -74,16 +53,12 @@
               </div>
 
               <footer class="fx-panel-actions">
-                <button
-                  type="button"
-                  class="fx-btn fx-btn-primary"
-                  @click="login()"
-                >Login <span class="fx-kbd">{{ shortcutLabels.login }}</span></button>
-                <button
-                  type="button"
-                  class="fx-btn fx-btn-ghost"
-                  @click="close()"
-                >Close <span class="fx-kbd">{{ shortcutLabels.close }}</span></button>
+                <button type="button" class="fx-btn fx-btn-primary" @click="login()">
+                  Login <span class="fx-kbd">{{ shortcutLabels.login }}</span>
+                </button>
+                <button type="button" class="fx-btn fx-btn-ghost" @click="close()">
+                  Close <span class="fx-kbd">{{ shortcutLabels.close }}</span>
+                </button>
               </footer>
             </div>
           </div>
@@ -95,10 +70,11 @@
 <script>
 import D3DApi from '@/services/api'
 import D3Util from '@/helpers/D3Util'
+import Shortcuts from '@/helpers/Shortcuts.js'
 export default {
   name: 'SiteLogin',
   props: ['active'],
-  data () {
+  data() {
     return {
       options: [],
       gNavLi: null,
@@ -113,14 +89,27 @@ export default {
   computed: {
     shortcutLabels() {
       return D3Util.shortcutLabels()
-    },
+    }
   },
-  mounted () {
+  mounted() {
     this.emitter.on('showLogin', () => {
       this.loginModal = true
     })
   },
   methods: {
+    onKeydown(event) {
+      if (Shortcuts.matches(event, 'close')) {
+        event.preventDefault()
+        this.close()
+      }
+    },
+    onKeyup(event) {
+      if (event.repeat) return
+      if (Shortcuts.matches(event, 'login')) {
+        event.preventDefault()
+        this.login()
+      }
+    },
     login: async function () {
       var result = await D3DApi.auth(this.username, this.password)
 
@@ -129,27 +118,23 @@ export default {
       }
       if (Object.prototype.hasOwnProperty.call(result, 'data')) {
         this.common()
-        this.emitter.emit('appMessage',
-          { message: 'Successfully Authenticated',
-            result: result
-          })
+        this.emitter.emit('appMessage', { message: 'Successfully Authenticated', result: result })
 
         // move this to a http-only secure cookie, instead of saving the cookie in localstorage
         localStorage.setItem('token', JSON.stringify(result.data.token).replace(/"/g, ''))
       } else {
-        this.emitter.emit('appMessage', {message: 'Failed to Authenticate', result: result})
+        this.emitter.emit('appMessage', { message: 'Failed to Authenticate', result: result })
       }
     },
-    close () {
+    close() {
       this.common()
     },
-    common (){
+    common() {
       this.loginModal = false
       this.emitter.emit('changeActive')
     }
-  },
+  }
 }
 </script>
 
-<style scoped>
-</style>
+<style scoped></style>

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -1,789 +1,1011 @@
 <template>
   <Teleport to="body">
     <transition name="fx-scrim">
-      <div
-        v-if="settingsModal"
-        class="fx-scrim"
-        @click="close()"
-      ></div>
+      <div v-if="settingsModal" class="fx-scrim" @click="close()"></div>
     </transition>
     <transition name="fx-panel">
-      <div
-        v-if="settingsModal"
-        class="fx-hud-stage"
-      >
-        <focus-trap
-          v-model:active="settingsModal"
-          class="trap is-active"
-        >
-          <div tabindex="0" class="fx-panel" @keydown.esc="close()">
+      <div v-if="settingsModal" class="fx-hud-stage">
+        <focus-trap v-model:active="settingsModal" class="trap is-active">
+          <div tabindex="0" class="fx-panel" @keydown="onKeydown($event)">
             <div class="fx-panel-inner">
               <header class="fx-panel-header">
                 <div class="fx-panel-title">
                   <span class="fx-title-chip fx-chip-settings">SETTINGS</span>
                   <h2 class="fx-title">Preferences</h2>
                 </div>
-                <button
-                  type="button"
-                  class="fx-close"
-                  aria-label="Close settings"
-                  @click="close()"
-                >✕</button>
+                <button type="button" class="fx-close" aria-label="Close settings" @click="close()">
+                  ✕
+                </button>
               </header>
               <div class="fx-readout">
                 <span class="fx-readout-kv fx-readout-wide">
                   <span class="fx-readout-k">STATUS</span>
                   <span class="fx-readout-v">{{ layoutModeLabel }} · Cytoscape.js</span>
                 </span>
-
               </div>
               <div class="fx-panel-body">
                 <div class="fx-settings-group">
-                <section class="fx-section">
-                  <h3 class="fx-section-title">General</h3>
-                  <div class="fx-section-body">
-                    <label class="fx-toggle">
-                      <div class="fx-toggle-text">
-                        <span>Show Help Pane</span>
-                        <small>Restores the floating assistant</small>
-                      </div>
-                      <input type="checkbox" v-model="settings.showHelpPane" />
-                      <span class="fx-toggle-track"></span>
-                    </label>
-                    <label class="fx-toggle">
-                      <div class="fx-toggle-text">
-                        <span>Enable Console Debugging</span>
-                        <small>Verbose logging for troubleshooting</small>
-                      </div>
-                      <input type="checkbox" v-model="settings.debug" />
-                      <span class="fx-toggle-track"></span>
-                    </label>
-                    <label class="fx-toggle">
-                      <div class="fx-toggle-text">
-                        <span>Show Graph Metadata</span>
-                        <small>Toggle the D3DInfo debug overlay</small>
-                      </div>
-                      <input type="checkbox" v-model="settings.d3dInfo" />
-                      <span class="fx-toggle-track"></span>
-                    </label>
-                    <label class="fx-field">
-                      <span class="fx-label">Server URL</span>
-                      <input
-                        class="fx-input"
-                        type="text"
-                        v-model="settings.serverUrl"
-                        placeholder="http://localhost:3000"
-                      />
-                      <small class="fx-toggle-note">Backend API URL. Change if your server runs on a different host or port.</small>
-                    </label>
-                    <div>
-                      <p class="fx-field-label">Theme</p>
-                      <div class="fx-pill-row">
-                        <button
-                          type="button"
-                          class="fx-pill"
-                          :class="{ 'is-active': settings.defaultTheme === 'light' }"
-                          @click="settings.defaultTheme = 'light'"
-                        >Light</button>
-                        <button
-                          type="button"
-                          class="fx-pill"
-                          :class="{ 'is-active': settings.defaultTheme === 'dark' }"
-                          @click="settings.defaultTheme = 'dark'"
-                        >Dark</button>
-                      </div>
-                    </div>
-                  </div>
-                </section>
-                </div>
-
-                <div class="fx-settings-group">
-                <section class="fx-section">
-                  <h3 class="fx-section-title">Hints</h3>
-                  <div class="fx-section-body">
-                    <label class="fx-field">
-                      <span class="fx-label">Hint Keys</span>
-                      <input
-                        class="fx-input"
-                        type="text"
-                        v-model="settings.hints"
-                        placeholder="asdfjklqweruiopzxcvnmgh"
-                      />
-                    </label>
-                    <div class="fx-grid">
-                      <label class="fx-field">
-                        <span class="fx-label">Hint Link Color</span>
-                        <input
-                          class="fx-input fx-input-color"
-                          type="color"
-                          v-model="settings.hintLinkColor"
-                        />
-                      </label>
-                      <label class="fx-field">
-                        <span class="fx-label">Hint Badge Background</span>
-                        <input
-                          class="fx-input fx-input-color"
-                          type="color"
-                          v-model="settings.hintBGColor"
-                        />
-                      </label>
-                    </div>
-                  </div>
-                </section>
-                </div>
-
-                <div class="fx-settings-group">
-                <section class="fx-section">
-                  <h3 class="fx-section-title">Layout Defaults</h3>
-                  <div class="fx-section-body">
-                    <div class="fx-grid">
-                      <div class="fx-field">
-                        <span class="fx-label">Default Layout Mode</span>
-                        <div class="fx-select">
-                          <button
-                            type="button"
-                            class="fx-select-trigger"
-                            @click.stop="toggleSel('layoutMode')"
-                          >{{ layoutModeLabel }}<span class="fx-caret">▾</span></button>
-                          <transition name="fx-drop">
-                            <ul v-if="openSel === 'layoutMode'" class="fx-options">
-                              <li
-                                v-for="opt in layoutModeOptions"
-                                :key="opt.value"
-                                class="fx-option"
-                                :class="{ 'fx-option-active': settings.defaultLayoutMode === opt.value }"
-                                @click="pick('defaultLayoutMode', opt.value)"
-                              >{{ opt.label }}</li>
-                            </ul>
-                          </transition>
+                  <section class="fx-section">
+                    <h3 class="fx-section-title">General</h3>
+                    <div class="fx-section-body">
+                      <label class="fx-toggle">
+                        <div class="fx-toggle-text">
+                          <span>Show Help Pane</span>
+                          <small>Restores the floating assistant</small>
                         </div>
-                      </div>
-                      <div v-if="settings.defaultLayoutMode === 'cola'" class="fx-field">
-                        <span class="fx-label">Flow Direction</span>
-                        <div class="fx-select">
+                        <input type="checkbox" v-model="settings.showHelpPane" />
+                        <span class="fx-toggle-track"></span>
+                      </label>
+                      <label class="fx-toggle">
+                        <div class="fx-toggle-text">
+                          <span>Enable Console Debugging</span>
+                          <small>Verbose logging for troubleshooting</small>
+                        </div>
+                        <input type="checkbox" v-model="settings.debug" />
+                        <span class="fx-toggle-track"></span>
+                      </label>
+                      <label class="fx-toggle">
+                        <div class="fx-toggle-text">
+                          <span>Show Graph Metadata</span>
+                          <small>Toggle the D3DInfo debug overlay</small>
+                        </div>
+                        <input type="checkbox" v-model="settings.d3dInfo" />
+                        <span class="fx-toggle-track"></span>
+                      </label>
+                      <label class="fx-field">
+                        <span class="fx-label">Server URL</span>
+                        <input
+                          class="fx-input"
+                          type="text"
+                          v-model="settings.serverUrl"
+                          placeholder="http://localhost:3000"
+                        />
+                        <small class="fx-toggle-note"
+                          >Backend API URL. Change if your server runs on a different host or
+                          port.</small
+                        >
+                      </label>
+                      <div>
+                        <p class="fx-field-label">Theme</p>
+                        <div class="fx-pill-row">
                           <button
                             type="button"
-                            class="fx-select-trigger"
-                            @click.stop="toggleSel('flow')"
-                          >{{ flowLabel }}<span class="fx-caret">▾</span></button>
-                          <transition name="fx-drop">
-                            <ul v-if="openSel === 'flow'" class="fx-options">
-                              <li
-                                v-for="opt in flowOptions"
-                                :key="opt.label"
-                                class="fx-option"
-                                :class="{ 'fx-option-active': settings.defaultColaFlow === opt.value }"
-                                @click="pick('defaultColaFlow', opt.value)"
-                              >{{ opt.label }}</li>
-                            </ul>
-                          </transition>
+                            class="fx-pill"
+                            :class="{ 'is-active': settings.defaultTheme === 'light' }"
+                            @click="settings.defaultTheme = 'light'"
+                          >
+                            Light
+                          </button>
+                          <button
+                            type="button"
+                            class="fx-pill"
+                            :class="{ 'is-active': settings.defaultTheme === 'dark' }"
+                            @click="settings.defaultTheme = 'dark'"
+                          >
+                            Dark
+                          </button>
                         </div>
                       </div>
                     </div>
-                    <div v-if="settings.defaultLayoutMode === 'cola'" class="fx-grid">
-                      <label class="fx-field">
-                        <span class="fx-label">Default Edge Length</span>
-                        <input class="fx-input" type="number" v-model.number="settings.defaultColaEdgeLength" />
-                      </label>
-                      <label class="fx-field">
-                        <span class="fx-label">Default Node Spacing</span>
-                        <input class="fx-input" type="number" v-model.number="settings.defaultColaNodeSpacing" />
-                      </label>
-                    </div>
-                    <div v-if="settings.defaultLayoutMode === 'cola'" class="fx-grid">
-                      <label class="fx-field">
-                        <span class="fx-label">Max Simulation Time (ms)</span>
-                        <input class="fx-input" type="number" v-model.number="settings.defaultColaMaxSimulationTime" />
-                      </label>
-                      <label class="fx-field">
-                        <span class="fx-label">Gravity</span>
-                        <input class="fx-input" type="number" min="0" step="0.1" v-model.number="settings.defaultColaGravity" />
-                        <small class="fx-toggle-note">0 = no pull; higher pulls disconnected nodes toward center.</small>
-                      </label>
-                    </div>
-                    <label v-if="settings.defaultLayoutMode === 'cola'" class="fx-toggle">
-                      <div class="fx-toggle-text">
-                        <span>Avoid Node Overlap</span>
-                        <small>Enforces separation of nodes</small>
-                      </div>
-                      <input type="checkbox" v-model="settings.defaultColaAvoidOverlap" />
-                      <span class="fx-toggle-track"></span>
-                    </label>
+                  </section>
+                </div>
 
-                    <template v-if="settings.defaultLayoutMode === 'cose'">
+                <div class="fx-settings-group">
+                  <section class="fx-section">
+                    <h3 class="fx-section-title">Shortcuts</h3>
+                    <div class="fx-section-body">
+                      <div
+                        v-for="group in shortcutGroups"
+                        :key="group.id"
+                        class="fx-shortcut-group"
+                      >
+                        <h4 class="fx-shortcut-group-title">{{ group.label }}</h4>
+                        <ShortcutRecorder
+                          v-for="action in group.actions"
+                          :key="action.id"
+                          :action-id="action.id"
+                          :label="action.label"
+                          v-model="settings.shortcuts[action.id]"
+                          :conflict-ids="shortcutConflicts(action.id)"
+                        />
+                      </div>
+                      <div class="fx-shortcut-actions">
+                        <button type="button" class="fx-btn-mini" @click="resetShortcuts">
+                          Reset all shortcuts to defaults
+                        </button>
+                      </div>
+                    </div>
+                  </section>
+                </div>
+
+                <div class="fx-settings-group">
+                  <section class="fx-section">
+                    <h3 class="fx-section-title">Hints</h3>
+                    <div class="fx-section-body">
+                      <label class="fx-field">
+                        <span class="fx-label">Hint Keys</span>
+                        <input
+                          class="fx-input"
+                          type="text"
+                          v-model="settings.hints"
+                          placeholder="asdfjklqweruiopzxcvnmgh"
+                        />
+                      </label>
                       <div class="fx-grid">
                         <label class="fx-field">
-                          <span class="fx-label">Node Repulsion</span>
-                          <input class="fx-input" type="number" min="0" step="10000" v-model.number="settings.defaultCoseNodeRepulsion" />
-                          <small class="fx-toggle-note">Higher = nodes push apart more.</small>
+                          <span class="fx-label">Hint Link Color</span>
+                          <input
+                            class="fx-input fx-input-color"
+                            type="color"
+                            v-model="settings.hintLinkColor"
+                          />
                         </label>
                         <label class="fx-field">
-                          <span class="fx-label">Ideal Edge Length</span>
-                          <input class="fx-input" type="number" min="1" v-model.number="settings.defaultCoseIdealEdgeLength" />
+                          <span class="fx-label">Hint Badge Background</span>
+                          <input
+                            class="fx-input fx-input-color"
+                            type="color"
+                            v-model="settings.hintBGColor"
+                          />
                         </label>
                       </div>
+                    </div>
+                  </section>
+                </div>
+
+                <div class="fx-settings-group">
+                  <section class="fx-section">
+                    <h3 class="fx-section-title">Layout Defaults</h3>
+                    <div class="fx-section-body">
                       <div class="fx-grid">
+                        <div class="fx-field">
+                          <span class="fx-label">Default Layout Mode</span>
+                          <div class="fx-select">
+                            <button
+                              type="button"
+                              class="fx-select-trigger"
+                              @click.stop="toggleSel('layoutMode')"
+                            >
+                              {{ layoutModeLabel }}<span class="fx-caret">▾</span>
+                            </button>
+                            <transition name="fx-drop">
+                              <ul v-if="openSel === 'layoutMode'" class="fx-options">
+                                <li
+                                  v-for="opt in layoutModeOptions"
+                                  :key="opt.value"
+                                  class="fx-option"
+                                  :class="{
+                                    'fx-option-active': settings.defaultLayoutMode === opt.value
+                                  }"
+                                  @click="pick('defaultLayoutMode', opt.value)"
+                                >
+                                  {{ opt.label }}
+                                </li>
+                              </ul>
+                            </transition>
+                          </div>
+                        </div>
+                        <div v-if="settings.defaultLayoutMode === 'cola'" class="fx-field">
+                          <span class="fx-label">Flow Direction</span>
+                          <div class="fx-select">
+                            <button
+                              type="button"
+                              class="fx-select-trigger"
+                              @click.stop="toggleSel('flow')"
+                            >
+                              {{ flowLabel }}<span class="fx-caret">▾</span>
+                            </button>
+                            <transition name="fx-drop">
+                              <ul v-if="openSel === 'flow'" class="fx-options">
+                                <li
+                                  v-for="opt in flowOptions"
+                                  :key="opt.label"
+                                  class="fx-option"
+                                  :class="{
+                                    'fx-option-active': settings.defaultColaFlow === opt.value
+                                  }"
+                                  @click="pick('defaultColaFlow', opt.value)"
+                                >
+                                  {{ opt.label }}
+                                </li>
+                              </ul>
+                            </transition>
+                          </div>
+                        </div>
+                      </div>
+                      <div v-if="settings.defaultLayoutMode === 'cola'" class="fx-grid">
+                        <label class="fx-field">
+                          <span class="fx-label">Default Edge Length</span>
+                          <input
+                            class="fx-input"
+                            type="number"
+                            v-model.number="settings.defaultColaEdgeLength"
+                          />
+                        </label>
+                        <label class="fx-field">
+                          <span class="fx-label">Default Node Spacing</span>
+                          <input
+                            class="fx-input"
+                            type="number"
+                            v-model.number="settings.defaultColaNodeSpacing"
+                          />
+                        </label>
+                      </div>
+                      <div v-if="settings.defaultLayoutMode === 'cola'" class="fx-grid">
+                        <label class="fx-field">
+                          <span class="fx-label">Max Simulation Time (ms)</span>
+                          <input
+                            class="fx-input"
+                            type="number"
+                            v-model.number="settings.defaultColaMaxSimulationTime"
+                          />
+                        </label>
                         <label class="fx-field">
                           <span class="fx-label">Gravity</span>
-                          <input class="fx-input" type="number" min="0" step="0.1" v-model.number="settings.defaultCoseGravity" />
-                          <small class="fx-toggle-note">Pulls nodes toward center.</small>
-                        </label>
-                        <label class="fx-field">
-                          <span class="fx-label">Node Overlap Padding</span>
-                          <input class="fx-input" type="number" min="0" v-model.number="settings.defaultCoseNodeOverlap" />
-                        </label>
-                      </div>
-                    </template>
-
-                    <template v-if="settings.defaultLayoutMode === 'breadthfirst'">
-                      <div class="fx-grid">
-                        <label class="fx-field">
-                          <span class="fx-label">Spacing Factor</span>
-                          <input class="fx-input" type="number" min="0.1" step="0.1" v-model.number="settings.defaultBreadthfirstSpacingFactor" />
+                          <input
+                            class="fx-input"
+                            type="number"
+                            min="0"
+                            step="0.1"
+                            v-model.number="settings.defaultColaGravity"
+                          />
+                          <small class="fx-toggle-note"
+                            >0 = no pull; higher pulls disconnected nodes toward center.</small
+                          >
                         </label>
                       </div>
-                      <label class="fx-toggle">
-                        <div class="fx-toggle-text">
-                          <span>Directed</span>
-                          <small>Respect edge direction in the tree</small>
-                        </div>
-                        <input type="checkbox" v-model="settings.defaultBreadthfirstDirected" />
-                        <span class="fx-toggle-track"></span>
-                      </label>
-                      <label class="fx-toggle">
-                        <div class="fx-toggle-text">
-                          <span>Circle</span>
-                          <small>Arrange as a circular tree</small>
-                        </div>
-                        <input type="checkbox" v-model="settings.defaultBreadthfirstCircle" />
-                        <span class="fx-toggle-track"></span>
-                      </label>
-                    </template>
-
-                    <template v-if="settings.defaultLayoutMode === 'grid'">
-                      <div class="fx-grid">
-                        <label class="fx-field">
-                          <span class="fx-label">Rows <em class="fx-opt">empty = auto</em></span>
-                          <input class="fx-input" type="number" min="1" v-model.number="settings.defaultGridRows" placeholder="auto" />
-                        </label>
-                        <label class="fx-field">
-                          <span class="fx-label">Columns <em class="fx-opt">empty = auto</em></span>
-                          <input class="fx-input" type="number" min="1" v-model.number="settings.defaultGridCols" placeholder="auto" />
-                        </label>
-                      </div>
-                      <div class="fx-grid">
-                        <label class="fx-field">
-                          <span class="fx-label">Spacing Factor</span>
-                          <input class="fx-input" type="number" min="0.1" step="0.1" v-model.number="settings.defaultGridSpacingFactor" />
-                        </label>
-                      </div>
-                      <label class="fx-toggle">
+                      <label v-if="settings.defaultLayoutMode === 'cola'" class="fx-toggle">
                         <div class="fx-toggle-text">
                           <span>Avoid Node Overlap</span>
                           <small>Enforces separation of nodes</small>
                         </div>
-                        <input type="checkbox" v-model="settings.defaultGridAvoidOverlap" />
+                        <input type="checkbox" v-model="settings.defaultColaAvoidOverlap" />
                         <span class="fx-toggle-track"></span>
                       </label>
-                    </template>
 
-                    <template v-if="settings.defaultLayoutMode === 'circle'">
-                      <div class="fx-grid">
-                        <label class="fx-field">
-                          <span class="fx-label">Spacing Factor</span>
-                          <input class="fx-input" type="number" min="0.1" step="0.1" v-model.number="settings.defaultCircleSpacingFactor" />
-                        </label>
-                      </div>
-                      <label class="fx-toggle">
-                        <div class="fx-toggle-text">
-                          <span>Clockwise</span>
-                          <small>Place nodes clockwise around the circle</small>
+                      <template v-if="settings.defaultLayoutMode === 'cose'">
+                        <div class="fx-grid">
+                          <label class="fx-field">
+                            <span class="fx-label">Node Repulsion</span>
+                            <input
+                              class="fx-input"
+                              type="number"
+                              min="0"
+                              step="10000"
+                              v-model.number="settings.defaultCoseNodeRepulsion"
+                            />
+                            <small class="fx-toggle-note">Higher = nodes push apart more.</small>
+                          </label>
+                          <label class="fx-field">
+                            <span class="fx-label">Ideal Edge Length</span>
+                            <input
+                              class="fx-input"
+                              type="number"
+                              min="1"
+                              v-model.number="settings.defaultCoseIdealEdgeLength"
+                            />
+                          </label>
                         </div>
-                        <input type="checkbox" v-model="settings.defaultCircleClockwise" />
-                        <span class="fx-toggle-track"></span>
-                      </label>
-                    </template>
+                        <div class="fx-grid">
+                          <label class="fx-field">
+                            <span class="fx-label">Gravity</span>
+                            <input
+                              class="fx-input"
+                              type="number"
+                              min="0"
+                              step="0.1"
+                              v-model.number="settings.defaultCoseGravity"
+                            />
+                            <small class="fx-toggle-note">Pulls nodes toward center.</small>
+                          </label>
+                          <label class="fx-field">
+                            <span class="fx-label">Node Overlap Padding</span>
+                            <input
+                              class="fx-input"
+                              type="number"
+                              min="0"
+                              v-model.number="settings.defaultCoseNodeOverlap"
+                            />
+                          </label>
+                        </div>
+                      </template>
 
-                    <template v-if="settings.defaultLayoutMode === 'concentric'">
-                      <div class="fx-grid">
-                        <label class="fx-field">
-                          <span class="fx-label">Spacing Factor</span>
-                          <input class="fx-input" type="number" min="0.1" step="0.1" v-model.number="settings.defaultConcentricSpacingFactor" />
-                        </label>
-                        <label class="fx-field">
-                          <span class="fx-label">Min Node Spacing</span>
-                          <input class="fx-input" type="number" min="0" v-model.number="settings.defaultConcentricMinNodeSpacing" />
-                        </label>
-                      </div>
-                      <label class="fx-toggle">
-                        <div class="fx-toggle-text">
-                          <span>Clockwise</span>
-                          <small>Place nodes clockwise around rings</small>
+                      <template v-if="settings.defaultLayoutMode === 'breadthfirst'">
+                        <div class="fx-grid">
+                          <label class="fx-field">
+                            <span class="fx-label">Spacing Factor</span>
+                            <input
+                              class="fx-input"
+                              type="number"
+                              min="0.1"
+                              step="0.1"
+                              v-model.number="settings.defaultBreadthfirstSpacingFactor"
+                            />
+                          </label>
                         </div>
-                        <input type="checkbox" v-model="settings.defaultConcentricClockwise" />
-                        <span class="fx-toggle-track"></span>
-                      </label>
-                      <label class="fx-toggle">
-                        <div class="fx-toggle-text">
-                          <span>Equidistant</span>
-                          <small>Equal distance between concentric rings</small>
-                        </div>
-                        <input type="checkbox" v-model="settings.defaultConcentricEquidistant" />
-                        <span class="fx-toggle-track"></span>
-                      </label>
-                    </template>
+                        <label class="fx-toggle">
+                          <div class="fx-toggle-text">
+                            <span>Directed</span>
+                            <small>Respect edge direction in the tree</small>
+                          </div>
+                          <input type="checkbox" v-model="settings.defaultBreadthfirstDirected" />
+                          <span class="fx-toggle-track"></span>
+                        </label>
+                        <label class="fx-toggle">
+                          <div class="fx-toggle-text">
+                            <span>Circle</span>
+                            <small>Arrange as a circular tree</small>
+                          </div>
+                          <input type="checkbox" v-model="settings.defaultBreadthfirstCircle" />
+                          <span class="fx-toggle-track"></span>
+                        </label>
+                      </template>
 
-                    <template v-if="settings.defaultLayoutMode === 'dagre'">
-                      <div class="fx-grid">
-                        <div class="fx-field">
-                          <span class="fx-label">Rank Direction</span>
-                          <div class="fx-select">
-                            <button
-                              type="button"
-                              class="fx-select-trigger"
-                              @click.stop="toggleSel('dagreRankDir')"
-                            >{{ dagreRankDirLabel }}<span class="fx-caret">▾</span></button>
-                            <transition name="fx-drop">
-                              <ul v-if="openSel === 'dagreRankDir'" class="fx-options">
-                                <li
-                                  v-for="opt in dagreRankDirOptions"
-                                  :key="opt.value"
-                                  class="fx-option"
-                                  :class="{ 'fx-option-active': settings.defaultDagreRankDir === opt.value }"
-                                  @click="pick('defaultDagreRankDir', opt.value)"
-                                >{{ opt.label }}</li>
-                              </ul>
-                            </transition>
+                      <template v-if="settings.defaultLayoutMode === 'grid'">
+                        <div class="fx-grid">
+                          <label class="fx-field">
+                            <span class="fx-label">Rows <em class="fx-opt">empty = auto</em></span>
+                            <input
+                              class="fx-input"
+                              type="number"
+                              min="1"
+                              v-model.number="settings.defaultGridRows"
+                              placeholder="auto"
+                            />
+                          </label>
+                          <label class="fx-field">
+                            <span class="fx-label"
+                              >Columns <em class="fx-opt">empty = auto</em></span
+                            >
+                            <input
+                              class="fx-input"
+                              type="number"
+                              min="1"
+                              v-model.number="settings.defaultGridCols"
+                              placeholder="auto"
+                            />
+                          </label>
+                        </div>
+                        <div class="fx-grid">
+                          <label class="fx-field">
+                            <span class="fx-label">Spacing Factor</span>
+                            <input
+                              class="fx-input"
+                              type="number"
+                              min="0.1"
+                              step="0.1"
+                              v-model.number="settings.defaultGridSpacingFactor"
+                            />
+                          </label>
+                        </div>
+                        <label class="fx-toggle">
+                          <div class="fx-toggle-text">
+                            <span>Avoid Node Overlap</span>
+                            <small>Enforces separation of nodes</small>
+                          </div>
+                          <input type="checkbox" v-model="settings.defaultGridAvoidOverlap" />
+                          <span class="fx-toggle-track"></span>
+                        </label>
+                      </template>
+
+                      <template v-if="settings.defaultLayoutMode === 'circle'">
+                        <div class="fx-grid">
+                          <label class="fx-field">
+                            <span class="fx-label">Spacing Factor</span>
+                            <input
+                              class="fx-input"
+                              type="number"
+                              min="0.1"
+                              step="0.1"
+                              v-model.number="settings.defaultCircleSpacingFactor"
+                            />
+                          </label>
+                        </div>
+                        <label class="fx-toggle">
+                          <div class="fx-toggle-text">
+                            <span>Clockwise</span>
+                            <small>Place nodes clockwise around the circle</small>
+                          </div>
+                          <input type="checkbox" v-model="settings.defaultCircleClockwise" />
+                          <span class="fx-toggle-track"></span>
+                        </label>
+                      </template>
+
+                      <template v-if="settings.defaultLayoutMode === 'concentric'">
+                        <div class="fx-grid">
+                          <label class="fx-field">
+                            <span class="fx-label">Spacing Factor</span>
+                            <input
+                              class="fx-input"
+                              type="number"
+                              min="0.1"
+                              step="0.1"
+                              v-model.number="settings.defaultConcentricSpacingFactor"
+                            />
+                          </label>
+                          <label class="fx-field">
+                            <span class="fx-label">Min Node Spacing</span>
+                            <input
+                              class="fx-input"
+                              type="number"
+                              min="0"
+                              v-model.number="settings.defaultConcentricMinNodeSpacing"
+                            />
+                          </label>
+                        </div>
+                        <label class="fx-toggle">
+                          <div class="fx-toggle-text">
+                            <span>Clockwise</span>
+                            <small>Place nodes clockwise around rings</small>
+                          </div>
+                          <input type="checkbox" v-model="settings.defaultConcentricClockwise" />
+                          <span class="fx-toggle-track"></span>
+                        </label>
+                        <label class="fx-toggle">
+                          <div class="fx-toggle-text">
+                            <span>Equidistant</span>
+                            <small>Equal distance between concentric rings</small>
+                          </div>
+                          <input type="checkbox" v-model="settings.defaultConcentricEquidistant" />
+                          <span class="fx-toggle-track"></span>
+                        </label>
+                      </template>
+
+                      <template v-if="settings.defaultLayoutMode === 'dagre'">
+                        <div class="fx-grid">
+                          <div class="fx-field">
+                            <span class="fx-label">Rank Direction</span>
+                            <div class="fx-select">
+                              <button
+                                type="button"
+                                class="fx-select-trigger"
+                                @click.stop="toggleSel('dagreRankDir')"
+                              >
+                                {{ dagreRankDirLabel }}<span class="fx-caret">▾</span>
+                              </button>
+                              <transition name="fx-drop">
+                                <ul v-if="openSel === 'dagreRankDir'" class="fx-options">
+                                  <li
+                                    v-for="opt in dagreRankDirOptions"
+                                    :key="opt.value"
+                                    class="fx-option"
+                                    :class="{
+                                      'fx-option-active': settings.defaultDagreRankDir === opt.value
+                                    }"
+                                    @click="pick('defaultDagreRankDir', opt.value)"
+                                  >
+                                    {{ opt.label }}
+                                  </li>
+                                </ul>
+                              </transition>
+                            </div>
+                          </div>
+                          <div class="fx-field">
+                            <span class="fx-label">Ranker Algorithm</span>
+                            <div class="fx-select">
+                              <button
+                                type="button"
+                                class="fx-select-trigger"
+                                @click.stop="toggleSel('dagreRanker')"
+                              >
+                                {{ dagreRankerLabel }}<span class="fx-caret">▾</span>
+                              </button>
+                              <transition name="fx-drop">
+                                <ul v-if="openSel === 'dagreRanker'" class="fx-options">
+                                  <li
+                                    v-for="opt in dagreRankerOptions"
+                                    :key="opt.value"
+                                    class="fx-option"
+                                    :class="{
+                                      'fx-option-active': settings.defaultDagreRanker === opt.value
+                                    }"
+                                    @click="pick('defaultDagreRanker', opt.value)"
+                                  >
+                                    {{ opt.label }}
+                                  </li>
+                                </ul>
+                              </transition>
+                            </div>
                           </div>
                         </div>
-                        <div class="fx-field">
-                          <span class="fx-label">Ranker Algorithm</span>
-                          <div class="fx-select">
-                            <button
-                              type="button"
-                              class="fx-select-trigger"
-                              @click.stop="toggleSel('dagreRanker')"
-                            >{{ dagreRankerLabel }}<span class="fx-caret">▾</span></button>
-                            <transition name="fx-drop">
-                              <ul v-if="openSel === 'dagreRanker'" class="fx-options">
-                                <li
-                                  v-for="opt in dagreRankerOptions"
-                                  :key="opt.value"
-                                  class="fx-option"
-                                  :class="{ 'fx-option-active': settings.defaultDagreRanker === opt.value }"
-                                  @click="pick('defaultDagreRanker', opt.value)"
-                                >{{ opt.label }}</li>
-                              </ul>
-                            </transition>
-                          </div>
+                        <div class="fx-grid">
+                          <label class="fx-field">
+                            <span class="fx-label">Node Separation</span>
+                            <input
+                              class="fx-input"
+                              type="number"
+                              min="0"
+                              v-model.number="settings.defaultDagreNodeSep"
+                            />
+                            <small class="fx-toggle-note"
+                              >Pixels between nodes in the same rank.</small
+                            >
+                          </label>
+                          <label class="fx-field">
+                            <span class="fx-label">Rank Separation</span>
+                            <input
+                              class="fx-input"
+                              type="number"
+                              min="0"
+                              v-model.number="settings.defaultDagreRankSep"
+                            />
+                            <small class="fx-toggle-note"
+                              >Pixels between ranks (rows/columns).</small
+                            >
+                          </label>
+                          <label class="fx-field">
+                            <span class="fx-label">Edge Separation</span>
+                            <input
+                              class="fx-input"
+                              type="number"
+                              min="0"
+                              v-model.number="settings.defaultDagreEdgeSep"
+                            />
+                          </label>
                         </div>
-                      </div>
-                      <div class="fx-grid">
-                        <label class="fx-field">
-                          <span class="fx-label">Node Separation</span>
-                          <input class="fx-input" type="number" min="0" v-model.number="settings.defaultDagreNodeSep" />
-                          <small class="fx-toggle-note">Pixels between nodes in the same rank.</small>
-                        </label>
-                        <label class="fx-field">
-                          <span class="fx-label">Rank Separation</span>
-                          <input class="fx-input" type="number" min="0" v-model.number="settings.defaultDagreRankSep" />
-                          <small class="fx-toggle-note">Pixels between ranks (rows/columns).</small>
-                        </label>
-                        <label class="fx-field">
-                          <span class="fx-label">Edge Separation</span>
-                          <input class="fx-input" type="number" min="0" v-model.number="settings.defaultDagreEdgeSep" />
-                        </label>
-                      </div>
-                    </template>
-                  </div>
-                </section>
-                </div>
-
-                <div class="fx-settings-group">
-                 <section class="fx-section">
-                   <h3 class="fx-section-title">Renderer</h3>
-                  <div class="fx-section-body">
-                    <label class="fx-toggle">
-                      <div class="fx-toggle-text">
-                        <span>Fit diagram to viewport on open</span>
-                        <small>Auto-zoom so the whole graph is visible</small>
-                      </div>
-                      <input type="checkbox" v-model="settings.defaultZoomFit" />
-                      <span class="fx-toggle-track"></span>
-                    </label>
-                    <label class="fx-field">
-                      <span class="fx-label">Fit Padding (px)</span>
-                      <input
-                        class="fx-input"
-                        type="number"
-                        step="1"
-                        min="0"
-                        max="200"
-                        v-model.number="settings.zoomFitFactor"
-                      />
-                      <small class="fx-toggle-note">Pixel padding around the graph when fitting to the viewport.</small>
-                    </label>
-                    <label class="fx-field">
-                      <span class="fx-label">Default Zoom Level</span>
-                      <input
-                        class="fx-input"
-                        type="number"
-                        step="0.1"
-                        min="0.1"
-                        max="5"
-                        v-model.number="settings.defaultZoomLevel"
-                      />
-                      <small class="fx-toggle-note">Zoom applied on open. With fit on: 1 = fit, 2 = twice as close, 0.5 = half. With fit off: absolute level.</small>
-                    </label>
-                    <label class="fx-field">
-                      <span class="fx-label">Arrowhead Size</span>
-                      <input
-                        class="fx-input"
-                        type="number"
-                        step="0.1"
-                        min="0.1"
-                        max="3"
-                        v-model.number="settings.defaultArrowScale"
-                      />
-                    </label>
-                  </div>
-                </section>
-                </div>
-
-                <div class="fx-settings-group">
-                <section class="fx-section">
-                  <h3 class="fx-section-title">New Node Defaults</h3>
-                  <div class="fx-section-body">
-                    <div class="fx-grid">
-                      <div class="fx-field">
-                        <span class="fx-label">Default Node Shape</span>
-                        <div class="fx-select">
-                          <button
-                            type="button"
-                            class="fx-select-trigger"
-                            @click.stop="toggleSel('nodeShape')"
-                          >{{ nodeShapeLabel }}<span class="fx-caret">▾</span></button>
-                          <transition name="fx-drop">
-                            <ul v-if="openSel === 'nodeShape'" class="fx-options">
-                              <li
-                                v-for="opt in nodeShapeOptions"
-                                :key="opt.value"
-                                class="fx-option"
-                                :class="{ 'fx-option-active': settings.defaultNodeShape === opt.value }"
-                                @click="pick('defaultNodeShape', opt.value)"
-                              >{{ opt.label }}</li>
-                            </ul>
-                          </transition>
-                        </div>
-                      </div>
-                      <div class="fx-field">
-                        <span class="fx-label">Label H-Align</span>
-                        <div class="fx-select">
-                          <button
-                            type="button"
-                            class="fx-select-trigger"
-                            @click.stop="toggleSel('halign')"
-                          >{{ halignLabel }}<span class="fx-caret">▾</span></button>
-                          <transition name="fx-drop">
-                            <ul v-if="openSel === 'halign'" class="fx-options">
-                              <li
-                                v-for="opt in nodeHalignOptions"
-                                :key="opt.value"
-                                class="fx-option"
-                                :class="{ 'fx-option-active': settings.defaultNodeTextHalign === opt.value }"
-                                @click="pick('defaultNodeTextHalign', opt.value)"
-                              >{{ opt.label }}</li>
-                            </ul>
-                          </transition>
-                        </div>
-                      </div>
-                      <div class="fx-field">
-                        <span class="fx-label">Label V-Align</span>
-                        <div class="fx-select">
-                          <button
-                            type="button"
-                            class="fx-select-trigger"
-                            @click.stop="toggleSel('valign')"
-                          >{{ valignLabel }}<span class="fx-caret">▾</span></button>
-                          <transition name="fx-drop">
-                            <ul v-if="openSel === 'valign'" class="fx-options">
-                              <li
-                                v-for="opt in nodeValignOptions"
-                                :key="opt.value"
-                                class="fx-option"
-                                :class="{ 'fx-option-active': settings.defaultNodeTextValign === opt.value }"
-                                @click="pick('defaultNodeTextValign', opt.value)"
-                              >{{ opt.label }}</li>
-                            </ul>
-                          </transition>
-                        </div>
-                      </div>
+                      </template>
                     </div>
-                    <div class="fx-grid">
-                       <label class="fx-field">
-                         <span class="fx-label">Default Node Label <em class="fx-opt">empty = no label</em></span>
-                         <input
-                           class="fx-input"
-                           type="text"
-                           v-model="settings.defaultNodeLabel"
-                           placeholder="empty = no label"
-                         />
-                       </label>
-                     </div>
-                     <div class="fx-grid">
-                       <label class="fx-field">
-                         <span class="fx-label">Background Color <em class="fx-opt">empty = theme</em></span>
-                         <div class="fx-color-row">
-                          <input
-                            class="fx-input fx-input-color"
-                            type="color"
-                            :value="settings.defaultNodeBgColor || '#5f9488'"
-                            @input="settings.defaultNodeBgColor = $event.target.value"
-                          />
-                          <button
-                            type="button"
-                            class="fx-btn fx-btn-mini"
-                            :class="{ 'fx-btn-active': !settings.defaultNodeBgColor }"
-                            @click="settings.defaultNodeBgColor = ''"
-                            title="Use theme color"
-                          >none</button>
+                  </section>
+                </div>
+
+                <div class="fx-settings-group">
+                  <section class="fx-section">
+                    <h3 class="fx-section-title">Renderer</h3>
+                    <div class="fx-section-body">
+                      <label class="fx-toggle">
+                        <div class="fx-toggle-text">
+                          <span>Fit diagram to viewport on open</span>
+                          <small>Auto-zoom so the whole graph is visible</small>
                         </div>
+                        <input type="checkbox" v-model="settings.defaultZoomFit" />
+                        <span class="fx-toggle-track"></span>
                       </label>
                       <label class="fx-field">
-                        <span class="fx-label">Border Color <em class="fx-opt">empty = theme</em></span>
-                        <div class="fx-color-row">
-                          <input
-                            class="fx-input fx-input-color"
-                            type="color"
-                            :value="settings.defaultNodeBorderColor || '#5e74ff'"
-                            @input="settings.defaultNodeBorderColor = $event.target.value"
-                          />
-                          <button
-                            type="button"
-                            class="fx-btn fx-btn-mini"
-                            :class="{ 'fx-btn-active': !settings.defaultNodeBorderColor }"
-                            @click="settings.defaultNodeBorderColor = ''"
-                            title="Use theme color"
-                          >none</button>
-                        </div>
-                      </label>
-                      <label class="fx-field">
-                        <span class="fx-label">Border Width <em class="fx-opt">empty = theme</em></span>
+                        <span class="fx-label">Fit Padding (px)</span>
                         <input
                           class="fx-input"
                           type="number"
-                          min="0"
-                          max="8"
-                          step="0.5"
-                          v-model.number="settings.defaultNodeBorderWidth"
-                          placeholder="theme"
-                        />
-                      </label>
-                      <label class="fx-field">
-                        <span class="fx-label">Font Size <em class="fx-opt">empty = theme</em></span>
-                        <input
-                          class="fx-input"
-                          type="number"
-                          min="8"
-                          max="28"
                           step="1"
-                          v-model.number="settings.defaultNodeFontSize"
-                          placeholder="theme"
+                          min="0"
+                          max="200"
+                          v-model.number="settings.zoomFitFactor"
+                        />
+                        <small class="fx-toggle-note"
+                          >Pixel padding around the graph when fitting to the viewport.</small
+                        >
+                      </label>
+                      <label class="fx-field">
+                        <span class="fx-label">Default Zoom Level</span>
+                        <input
+                          class="fx-input"
+                          type="number"
+                          step="0.1"
+                          min="0.1"
+                          max="5"
+                          v-model.number="settings.defaultZoomLevel"
+                        />
+                        <small class="fx-toggle-note"
+                          >Zoom applied on open. With fit on: 1 = fit, 2 = twice as close, 0.5 =
+                          half. With fit off: absolute level.</small
+                        >
+                      </label>
+                      <label class="fx-field">
+                        <span class="fx-label">Arrowhead Size</span>
+                        <input
+                          class="fx-input"
+                          type="number"
+                          step="0.1"
+                          min="0.1"
+                          max="3"
+                          v-model.number="settings.defaultArrowScale"
                         />
                       </label>
                     </div>
-                  </div>
-                </section>
+                  </section>
                 </div>
 
                 <div class="fx-settings-group">
-                <section class="fx-section">
-                  <h3 class="fx-section-title">New Edge Defaults</h3>
-                   <div class="fx-section-body">
-                     <div class="fx-grid">
-                       <label class="fx-field">
-                         <span class="fx-label">Default Edge Label <em class="fx-opt">empty = no label</em></span>
-                         <input
-                           class="fx-input"
-                           type="text"
-                           v-model="settings.defaultEdgeLabel"
-                           placeholder="empty = no label"
-                         />
-                       </label>
-                     </div>
-                     <div class="fx-grid">
-                       <div class="fx-field">
-                         <span class="fx-label">Edge Arrow Style</span>
-                        <div class="fx-select">
-                          <button
-                            type="button"
-                            class="fx-select-trigger"
-                            @click.stop="toggleSel('edgeArrowStyle')"
-                          >{{ edgeArrowHeadStyleLabel }}<span class="fx-caret">▾</span></button>
-                          <transition name="fx-drop">
-                            <ul v-if="openSel === 'edgeArrowStyle'" class="fx-options">
-                              <li
-                                v-for="opt in edgeArrowHeadStyleOptions"
-                                :key="opt.value"
-                                class="fx-option"
-                                :class="{ 'fx-option-active': settings.defaultEdgeArrowHeadStyle === opt.value }"
-                                @click="pick('defaultEdgeArrowHeadStyle', opt.value)"
-                              >{{ opt.label }}</li>
-                            </ul>
-                          </transition>
+                  <section class="fx-section">
+                    <h3 class="fx-section-title">New Node Defaults</h3>
+                    <div class="fx-section-body">
+                      <div class="fx-grid">
+                        <div class="fx-field">
+                          <span class="fx-label">Default Node Shape</span>
+                          <div class="fx-select">
+                            <button
+                              type="button"
+                              class="fx-select-trigger"
+                              @click.stop="toggleSel('nodeShape')"
+                            >
+                              {{ nodeShapeLabel }}<span class="fx-caret">▾</span>
+                            </button>
+                            <transition name="fx-drop">
+                              <ul v-if="openSel === 'nodeShape'" class="fx-options">
+                                <li
+                                  v-for="opt in nodeShapeOptions"
+                                  :key="opt.value"
+                                  class="fx-option"
+                                  :class="{
+                                    'fx-option-active': settings.defaultNodeShape === opt.value
+                                  }"
+                                  @click="pick('defaultNodeShape', opt.value)"
+                                >
+                                  {{ opt.label }}
+                                </li>
+                              </ul>
+                            </transition>
+                          </div>
+                        </div>
+                        <div class="fx-field">
+                          <span class="fx-label">Label H-Align</span>
+                          <div class="fx-select">
+                            <button
+                              type="button"
+                              class="fx-select-trigger"
+                              @click.stop="toggleSel('halign')"
+                            >
+                              {{ halignLabel }}<span class="fx-caret">▾</span>
+                            </button>
+                            <transition name="fx-drop">
+                              <ul v-if="openSel === 'halign'" class="fx-options">
+                                <li
+                                  v-for="opt in nodeHalignOptions"
+                                  :key="opt.value"
+                                  class="fx-option"
+                                  :class="{
+                                    'fx-option-active': settings.defaultNodeTextHalign === opt.value
+                                  }"
+                                  @click="pick('defaultNodeTextHalign', opt.value)"
+                                >
+                                  {{ opt.label }}
+                                </li>
+                              </ul>
+                            </transition>
+                          </div>
+                        </div>
+                        <div class="fx-field">
+                          <span class="fx-label">Label V-Align</span>
+                          <div class="fx-select">
+                            <button
+                              type="button"
+                              class="fx-select-trigger"
+                              @click.stop="toggleSel('valign')"
+                            >
+                              {{ valignLabel }}<span class="fx-caret">▾</span>
+                            </button>
+                            <transition name="fx-drop">
+                              <ul v-if="openSel === 'valign'" class="fx-options">
+                                <li
+                                  v-for="opt in nodeValignOptions"
+                                  :key="opt.value"
+                                  class="fx-option"
+                                  :class="{
+                                    'fx-option-active': settings.defaultNodeTextValign === opt.value
+                                  }"
+                                  @click="pick('defaultNodeTextValign', opt.value)"
+                                >
+                                  {{ opt.label }}
+                                </li>
+                              </ul>
+                            </transition>
+                          </div>
                         </div>
                       </div>
-                      <div class="fx-field">
-                        <span class="fx-label">Default Arrow Shape</span>
-                        <div class="fx-select">
-                          <button
-                            type="button"
-                            class="fx-select-trigger"
-                            @click.stop="toggleSel('arrowShape')"
-                          >{{ arrowShapeLabel }}<span class="fx-caret">▾</span></button>
-                          <transition name="fx-drop">
-                            <ul v-if="openSel === 'arrowShape'" class="fx-options">
-                              <li
-                                v-for="opt in edgeArrowHeadOptions"
-                                :key="opt.value"
-                                class="fx-option"
-                                :class="{ 'fx-option-active': settings.defaultArrowShape === opt.value }"
-                                @click="pick('defaultArrowShape', opt.value)"
-                              >{{ opt.label }}</li>
-                            </ul>
-                          </transition>
-                        </div>
-                      </div>
-                      <div class="fx-field">
-                        <span class="fx-label">Source Arrow <em class="fx-opt">empty = none</em></span>
-                        <div class="fx-select">
-                          <button
-                            type="button"
-                            class="fx-select-trigger"
-                            @click.stop="toggleSel('sourceArrow')"
-                          >{{ sourceArrowLabel }}<span class="fx-caret">▾</span></button>
-                          <transition name="fx-drop">
-                            <ul v-if="openSel === 'sourceArrow'" class="fx-options">
-                              <li
-                                class="fx-option"
-                                :class="{ 'fx-option-active': !settings.defaultEdgeSourceArrow }"
-                                @click="pick('defaultEdgeSourceArrow', '')"
-                              >— none —</li>
-                              <li
-                                v-for="opt in edgeArrowHeadOptions"
-                                :key="opt.value"
-                                class="fx-option"
-                                :class="{ 'fx-option-active': settings.defaultEdgeSourceArrow === opt.value }"
-                                @click="pick('defaultEdgeSourceArrow', opt.value)"
-                              >{{ opt.label }}</li>
-                            </ul>
-                          </transition>
-                        </div>
-                      </div>
-                      <div class="fx-field">
-                        <span class="fx-label">Edge Line Style</span>
-                        <div class="fx-select">
-                          <button
-                            type="button"
-                            class="fx-select-trigger"
-                            @click.stop="toggleSel('lineStyle')"
-                          >{{ lineStyleLabel }}<span class="fx-caret">▾</span></button>
-                          <transition name="fx-drop">
-                            <ul v-if="openSel === 'lineStyle'" class="fx-options">
-                              <li
-                                v-for="opt in edgeLineStyleOptions"
-                                :key="opt.value"
-                                class="fx-option"
-                                :class="{ 'fx-option-active': settings.defaultEdgeLineStyle === opt.value }"
-                                @click="pick('defaultEdgeLineStyle', opt.value)"
-                              >{{ opt.label }}</li>
-                            </ul>
-                          </transition>
-                        </div>
-                      </div>
-                    </div>
-                    <div class="fx-grid">
-                      <div class="fx-field">
-                        <span class="fx-label">Curve Style</span>
-                        <div class="fx-select">
-                          <button
-                            type="button"
-                            class="fx-select-trigger"
-                            @click.stop="toggleSel('curveStyle')"
-                          >{{ curveStyleLabel }}<span class="fx-caret">▾</span></button>
-                          <transition name="fx-drop">
-                            <ul v-if="openSel === 'curveStyle'" class="fx-options">
-                              <li
-                                v-for="opt in edgeCurveOptions"
-                                :key="opt.value"
-                                class="fx-option"
-                                :class="{ 'fx-option-active': settings.defaultEdgeStyle === opt.value }"
-                                @click="pick('defaultEdgeStyle', opt.value)"
-                              >{{ opt.label }}</li>
-                            </ul>
-                          </transition>
-                        </div>
-                      </div>
-                      <label class="fx-field">
-                        <span class="fx-label">Edge Color <em class="fx-opt">empty = theme</em></span>
-                        <div class="fx-color-row">
+                      <div class="fx-grid">
+                        <label class="fx-field">
+                          <span class="fx-label"
+                            >Default Node Label <em class="fx-opt">empty = no label</em></span
+                          >
                           <input
-                            class="fx-input fx-input-color"
-                            type="color"
-                            :value="settings.defaultEdgeColor || '#5e74ff'"
-                            @input="settings.defaultEdgeColor = $event.target.value"
+                            class="fx-input"
+                            type="text"
+                            v-model="settings.defaultNodeLabel"
+                            placeholder="empty = no label"
                           />
-                          <button
-                            type="button"
-                            class="fx-btn fx-btn-mini"
-                            :class="{ 'fx-btn-active': !settings.defaultEdgeColor }"
-                            @click="settings.defaultEdgeColor = ''"
-                            title="Use theme color"
-                          >none</button>
-                        </div>
-                      </label>
-                      <label class="fx-field">
-                        <span class="fx-label">Edge Thickness</span>
-                        <input
-                          class="fx-input"
-                          type="number"
-                          min="1"
-                          max="10"
-                          v-model.number="settings.defaultEdgeWidth"
-                        />
-                      </label>
-                      <label class="fx-field">
-                        <span class="fx-label">Edge Opacity</span>
-                        <input
-                          class="fx-input"
-                          type="number"
-                          step="0.05"
-                          min="0.1"
-                          max="1"
-                          v-model.number="settings.defaultEdgeOpacity"
-                        />
-                      </label>
+                        </label>
+                      </div>
+                      <div class="fx-grid">
+                        <label class="fx-field">
+                          <span class="fx-label"
+                            >Background Color <em class="fx-opt">empty = theme</em></span
+                          >
+                          <div class="fx-color-row">
+                            <input
+                              class="fx-input fx-input-color"
+                              type="color"
+                              :value="settings.defaultNodeBgColor || '#5f9488'"
+                              @input="settings.defaultNodeBgColor = $event.target.value"
+                            />
+                            <button
+                              type="button"
+                              class="fx-btn fx-btn-mini"
+                              :class="{ 'fx-btn-active': !settings.defaultNodeBgColor }"
+                              @click="settings.defaultNodeBgColor = ''"
+                              title="Use theme color"
+                            >
+                              none
+                            </button>
+                          </div>
+                        </label>
+                        <label class="fx-field">
+                          <span class="fx-label"
+                            >Border Color <em class="fx-opt">empty = theme</em></span
+                          >
+                          <div class="fx-color-row">
+                            <input
+                              class="fx-input fx-input-color"
+                              type="color"
+                              :value="settings.defaultNodeBorderColor || '#5e74ff'"
+                              @input="settings.defaultNodeBorderColor = $event.target.value"
+                            />
+                            <button
+                              type="button"
+                              class="fx-btn fx-btn-mini"
+                              :class="{ 'fx-btn-active': !settings.defaultNodeBorderColor }"
+                              @click="settings.defaultNodeBorderColor = ''"
+                              title="Use theme color"
+                            >
+                              none
+                            </button>
+                          </div>
+                        </label>
+                        <label class="fx-field">
+                          <span class="fx-label"
+                            >Border Width <em class="fx-opt">empty = theme</em></span
+                          >
+                          <input
+                            class="fx-input"
+                            type="number"
+                            min="0"
+                            max="8"
+                            step="0.5"
+                            v-model.number="settings.defaultNodeBorderWidth"
+                            placeholder="theme"
+                          />
+                        </label>
+                        <label class="fx-field">
+                          <span class="fx-label"
+                            >Font Size <em class="fx-opt">empty = theme</em></span
+                          >
+                          <input
+                            class="fx-input"
+                            type="number"
+                            min="8"
+                            max="28"
+                            step="1"
+                            v-model.number="settings.defaultNodeFontSize"
+                            placeholder="theme"
+                          />
+                        </label>
+                      </div>
                     </div>
-                  </div>
-                </section>
+                  </section>
+                </div>
+
+                <div class="fx-settings-group">
+                  <section class="fx-section">
+                    <h3 class="fx-section-title">New Edge Defaults</h3>
+                    <div class="fx-section-body">
+                      <div class="fx-grid">
+                        <label class="fx-field">
+                          <span class="fx-label"
+                            >Default Edge Label <em class="fx-opt">empty = no label</em></span
+                          >
+                          <input
+                            class="fx-input"
+                            type="text"
+                            v-model="settings.defaultEdgeLabel"
+                            placeholder="empty = no label"
+                          />
+                        </label>
+                      </div>
+                      <div class="fx-grid">
+                        <div class="fx-field">
+                          <span class="fx-label">Edge Arrow Style</span>
+                          <div class="fx-select">
+                            <button
+                              type="button"
+                              class="fx-select-trigger"
+                              @click.stop="toggleSel('edgeArrowStyle')"
+                            >
+                              {{ edgeArrowHeadStyleLabel }}<span class="fx-caret">▾</span>
+                            </button>
+                            <transition name="fx-drop">
+                              <ul v-if="openSel === 'edgeArrowStyle'" class="fx-options">
+                                <li
+                                  v-for="opt in edgeArrowHeadStyleOptions"
+                                  :key="opt.value"
+                                  class="fx-option"
+                                  :class="{
+                                    'fx-option-active':
+                                      settings.defaultEdgeArrowHeadStyle === opt.value
+                                  }"
+                                  @click="pick('defaultEdgeArrowHeadStyle', opt.value)"
+                                >
+                                  {{ opt.label }}
+                                </li>
+                              </ul>
+                            </transition>
+                          </div>
+                        </div>
+                        <div class="fx-field">
+                          <span class="fx-label">Default Arrow Shape</span>
+                          <div class="fx-select">
+                            <button
+                              type="button"
+                              class="fx-select-trigger"
+                              @click.stop="toggleSel('arrowShape')"
+                            >
+                              {{ arrowShapeLabel }}<span class="fx-caret">▾</span>
+                            </button>
+                            <transition name="fx-drop">
+                              <ul v-if="openSel === 'arrowShape'" class="fx-options">
+                                <li
+                                  v-for="opt in edgeArrowHeadOptions"
+                                  :key="opt.value"
+                                  class="fx-option"
+                                  :class="{
+                                    'fx-option-active': settings.defaultArrowShape === opt.value
+                                  }"
+                                  @click="pick('defaultArrowShape', opt.value)"
+                                >
+                                  {{ opt.label }}
+                                </li>
+                              </ul>
+                            </transition>
+                          </div>
+                        </div>
+                        <div class="fx-field">
+                          <span class="fx-label"
+                            >Source Arrow <em class="fx-opt">empty = none</em></span
+                          >
+                          <div class="fx-select">
+                            <button
+                              type="button"
+                              class="fx-select-trigger"
+                              @click.stop="toggleSel('sourceArrow')"
+                            >
+                              {{ sourceArrowLabel }}<span class="fx-caret">▾</span>
+                            </button>
+                            <transition name="fx-drop">
+                              <ul v-if="openSel === 'sourceArrow'" class="fx-options">
+                                <li
+                                  class="fx-option"
+                                  :class="{ 'fx-option-active': !settings.defaultEdgeSourceArrow }"
+                                  @click="pick('defaultEdgeSourceArrow', '')"
+                                >
+                                  — none —
+                                </li>
+                                <li
+                                  v-for="opt in edgeArrowHeadOptions"
+                                  :key="opt.value"
+                                  class="fx-option"
+                                  :class="{
+                                    'fx-option-active':
+                                      settings.defaultEdgeSourceArrow === opt.value
+                                  }"
+                                  @click="pick('defaultEdgeSourceArrow', opt.value)"
+                                >
+                                  {{ opt.label }}
+                                </li>
+                              </ul>
+                            </transition>
+                          </div>
+                        </div>
+                        <div class="fx-field">
+                          <span class="fx-label">Edge Line Style</span>
+                          <div class="fx-select">
+                            <button
+                              type="button"
+                              class="fx-select-trigger"
+                              @click.stop="toggleSel('lineStyle')"
+                            >
+                              {{ lineStyleLabel }}<span class="fx-caret">▾</span>
+                            </button>
+                            <transition name="fx-drop">
+                              <ul v-if="openSel === 'lineStyle'" class="fx-options">
+                                <li
+                                  v-for="opt in edgeLineStyleOptions"
+                                  :key="opt.value"
+                                  class="fx-option"
+                                  :class="{
+                                    'fx-option-active': settings.defaultEdgeLineStyle === opt.value
+                                  }"
+                                  @click="pick('defaultEdgeLineStyle', opt.value)"
+                                >
+                                  {{ opt.label }}
+                                </li>
+                              </ul>
+                            </transition>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="fx-grid">
+                        <div class="fx-field">
+                          <span class="fx-label">Curve Style</span>
+                          <div class="fx-select">
+                            <button
+                              type="button"
+                              class="fx-select-trigger"
+                              @click.stop="toggleSel('curveStyle')"
+                            >
+                              {{ curveStyleLabel }}<span class="fx-caret">▾</span>
+                            </button>
+                            <transition name="fx-drop">
+                              <ul v-if="openSel === 'curveStyle'" class="fx-options">
+                                <li
+                                  v-for="opt in edgeCurveOptions"
+                                  :key="opt.value"
+                                  class="fx-option"
+                                  :class="{
+                                    'fx-option-active': settings.defaultEdgeStyle === opt.value
+                                  }"
+                                  @click="pick('defaultEdgeStyle', opt.value)"
+                                >
+                                  {{ opt.label }}
+                                </li>
+                              </ul>
+                            </transition>
+                          </div>
+                        </div>
+                        <label class="fx-field">
+                          <span class="fx-label"
+                            >Edge Color <em class="fx-opt">empty = theme</em></span
+                          >
+                          <div class="fx-color-row">
+                            <input
+                              class="fx-input fx-input-color"
+                              type="color"
+                              :value="settings.defaultEdgeColor || '#5e74ff'"
+                              @input="settings.defaultEdgeColor = $event.target.value"
+                            />
+                            <button
+                              type="button"
+                              class="fx-btn fx-btn-mini"
+                              :class="{ 'fx-btn-active': !settings.defaultEdgeColor }"
+                              @click="settings.defaultEdgeColor = ''"
+                              title="Use theme color"
+                            >
+                              none
+                            </button>
+                          </div>
+                        </label>
+                        <label class="fx-field">
+                          <span class="fx-label">Edge Thickness</span>
+                          <input
+                            class="fx-input"
+                            type="number"
+                            min="1"
+                            max="10"
+                            v-model.number="settings.defaultEdgeWidth"
+                          />
+                        </label>
+                        <label class="fx-field">
+                          <span class="fx-label">Edge Opacity</span>
+                          <input
+                            class="fx-input"
+                            type="number"
+                            step="0.05"
+                            min="0.1"
+                            max="1"
+                            v-model.number="settings.defaultEdgeOpacity"
+                          />
+                        </label>
+                      </div>
+                    </div>
+                  </section>
                 </div>
               </div>
               <footer class="fx-panel-actions">
-                <button
-                  type="button"
-                  class="fx-btn fx-btn-primary"
-                  @click="save()"
-                >Save ({{ shortcutLabels.save }})</button>
-                <button
-                  type="button"
-                  class="fx-btn fx-btn-ghost"
-                  @click="resetSettings()"
-                >Reset Defaults</button>
-                <button
-                  type="button"
-                  class="fx-btn fx-btn-ghost"
-                  @click="close()"
-                >Close ({{ shortcutLabels.close }})</button>
+                <button type="button" class="fx-btn fx-btn-primary" @click="save()">
+                  Save ({{ shortcutLabels.save }})
+                </button>
+                <button type="button" class="fx-btn fx-btn-ghost" @click="resetSettings()">
+                  Reset Defaults
+                </button>
+                <button type="button" class="fx-btn fx-btn-ghost" @click="close()">
+                  Close ({{ shortcutLabels.close }})
+                </button>
               </footer>
             </div>
           </div>
@@ -795,35 +1017,45 @@
 
 <script>
 import D3Util from '@/helpers/D3Util'
+import Shortcuts, { SHORTCUT_GROUPS } from '@/helpers/Shortcuts.js'
+import ShortcutRecorder from '@/components/ShortcutRecorder.vue'
 
 export default {
   name: 'SettingsDialog',
   props: ['active', 'd3dInfo'],
+  components: { ShortcutRecorder },
   inheritAttrs: false,
-  data () {
+  data() {
     return {
       settingsModal: false,
       openSel: null,
       settings: this.cloneDefaults(),
       flowOptions: [
-        { label: 'None',           value: null },
+        { label: 'None', value: null },
         { label: 'Horizontal (x)', value: 'x' },
-        { label: 'Vertical (y)',   value: 'y' },
+        { label: 'Vertical (y)', value: 'y' }
       ],
       dagreRankDirOptions: [
         { label: 'Top → Bottom', value: 'TB' },
         { label: 'Bottom → Top', value: 'BT' },
         { label: 'Left → Right', value: 'LR' },
-        { label: 'Right → Left', value: 'RL' },
+        { label: 'Right → Left', value: 'RL' }
       ],
       dagreRankerOptions: [
         { label: 'Network Simplex', value: 'network-simplex' },
-        { label: 'Tight Tree',      value: 'tight-tree' },
-        { label: 'Longest Path',    value: 'longest-path' },
-      ],
+        { label: 'Tight Tree', value: 'tight-tree' },
+        { label: 'Longest Path', value: 'longest-path' }
+      ]
     }
   },
   computed: {
+    shortcutGroups() {
+      return SHORTCUT_GROUPS.map((group) => ({
+        id: group.id,
+        label: group.label,
+        actions: Shortcuts.actions.filter((a) => a.group === group.id)
+      }))
+    },
     shortcutLabels() {
       return D3Util.shortcutLabels()
     },
@@ -858,10 +1090,18 @@ export default {
       return this._optLabel(this.flowOptions, this.settings.defaultColaFlow, 'None')
     },
     dagreRankDirLabel() {
-      return this._optLabel(this.dagreRankDirOptions, this.settings.defaultDagreRankDir, 'Top → Bottom')
+      return this._optLabel(
+        this.dagreRankDirOptions,
+        this.settings.defaultDagreRankDir,
+        'Top → Bottom'
+      )
     },
     dagreRankerLabel() {
-      return this._optLabel(this.dagreRankerOptions, this.settings.defaultDagreRanker, 'Network Simplex')
+      return this._optLabel(
+        this.dagreRankerOptions,
+        this.settings.defaultDagreRanker,
+        'Network Simplex'
+      )
     },
     nodeShapeLabel() {
       return this._optLabel(this.nodeShapeOptions, this.settings.defaultNodeShape, 'Rectangle')
@@ -873,23 +1113,31 @@ export default {
       return this._optLabel(this.nodeValignOptions, this.settings.defaultNodeTextValign, 'Top')
     },
     edgeArrowHeadStyleLabel() {
-      return this._optLabel(this.edgeArrowHeadStyleOptions, this.settings.defaultEdgeArrowHeadStyle, 'Filled')
+      return this._optLabel(
+        this.edgeArrowHeadStyleOptions,
+        this.settings.defaultEdgeArrowHeadStyle,
+        'Filled'
+      )
     },
     arrowShapeLabel() {
       return this._optLabel(this.edgeArrowHeadOptions, this.settings.defaultArrowShape, 'Vee')
     },
     sourceArrowLabel() {
       if (!this.settings.defaultEdgeSourceArrow) return '— none —'
-      return this._optLabel(this.edgeArrowHeadOptions, this.settings.defaultEdgeSourceArrow, this.settings.defaultEdgeSourceArrow)
+      return this._optLabel(
+        this.edgeArrowHeadOptions,
+        this.settings.defaultEdgeSourceArrow,
+        this.settings.defaultEdgeSourceArrow
+      )
     },
     lineStyleLabel() {
       return this._optLabel(this.edgeLineStyleOptions, this.settings.defaultEdgeLineStyle, 'Solid')
     },
     curveStyleLabel() {
       return this._optLabel(this.edgeCurveOptions, this.settings.defaultEdgeStyle, 'Bezier')
-    },
+    }
   },
-  mounted () {
+  mounted() {
     document.addEventListener('click', this.onDocClick)
 
     const defaults = this.cloneDefaults()
@@ -905,13 +1153,37 @@ export default {
       this.settingsModal = true
     })
   },
-  beforeUnmount () {
+  beforeUnmount() {
     document.removeEventListener('click', this.onDocClick)
   },
   methods: {
+    onKeydown(event) {
+      if (Shortcuts.matches(event, 'close')) {
+        event.preventDefault()
+        this.close()
+      }
+    },
+    // Action ids whose effective combo matches the one currently used by the
+    // given action (so the recorder can flag conflicting assignments).
+    shortcutConflicts(actionId) {
+      const target = Shortcuts.action(actionId)
+      if (!target) return []
+      const combo =
+        this.settings.shortcuts[actionId] || (Shortcuts.isMac() ? target.mac : target.other)
+      return Shortcuts.actions
+        .filter((a) => {
+          if (a.id === actionId) return false
+          const other = this.settings.shortcuts[a.id] || (Shortcuts.isMac() ? a.mac : a.other)
+          return other === combo
+        })
+        .map((a) => a.id)
+    },
+    resetShortcuts() {
+      this.settings.shortcuts = {}
+    },
     _optLabel(list, val, fallback) {
       if (val === null || val === undefined || val === '') return fallback
-      const opt = list.find(o => o.value === val)
+      const opt = list.find((o) => o.value === val)
       return opt ? opt.label : fallback
     },
     toggleSel(key) {
@@ -930,6 +1202,7 @@ export default {
     },
     mergeWithDefaults(stored, defaults) {
       const merged = { ...defaults, ...stored }
+      merged.shortcuts = { ...defaults.shortcuts, ...(stored.shortcuts || {}) }
       merged.themes = stored.themes || defaults.themes
       merged.hints = stored.hints || defaults.hints
       merged.hintLinkColor = this.expandHex(stored.hintLinkColor) || defaults.hintLinkColor
@@ -939,86 +1212,190 @@ export default {
       merged.d3dInfo = Boolean(stored.d3dInfo)
       merged.showHelpPane = Boolean(stored.showHelpPane)
       merged.zoomFitFactor = Number(stored.zoomFitFactor) || defaults.zoomFitFactor
-      merged.defaultZoomFit = stored.defaultZoomFit !== undefined ? Boolean(stored.defaultZoomFit) : defaults.defaultZoomFit
-      merged.defaultZoomLevel = stored.defaultZoomLevel !== undefined ? Number(stored.defaultZoomLevel) : defaults.defaultZoomLevel
+      merged.defaultZoomFit =
+        stored.defaultZoomFit !== undefined
+          ? Boolean(stored.defaultZoomFit)
+          : defaults.defaultZoomFit
+      merged.defaultZoomLevel =
+        stored.defaultZoomLevel !== undefined
+          ? Number(stored.defaultZoomLevel)
+          : defaults.defaultZoomLevel
       merged.defaultLayoutMode = stored.defaultLayoutMode || defaults.defaultLayoutMode
-      merged.defaultColaEdgeLength = stored.defaultColaEdgeLength !== undefined ? Number(stored.defaultColaEdgeLength) : defaults.defaultColaEdgeLength
-      merged.defaultColaNodeSpacing = stored.defaultColaNodeSpacing !== undefined ? Number(stored.defaultColaNodeSpacing) : defaults.defaultColaNodeSpacing
-      merged.defaultColaFlow = stored.defaultColaFlow !== undefined ? stored.defaultColaFlow : defaults.defaultColaFlow
-      merged.defaultColaAvoidOverlap = stored.defaultColaAvoidOverlap !== undefined ? Boolean(stored.defaultColaAvoidOverlap) : defaults.defaultColaAvoidOverlap
-      merged.defaultColaMaxSimulationTime = stored.defaultColaMaxSimulationTime !== undefined ? Number(stored.defaultColaMaxSimulationTime) : defaults.defaultColaMaxSimulationTime
-      merged.defaultColaGravity = stored.defaultColaGravity !== undefined ? Number(stored.defaultColaGravity) : defaults.defaultColaGravity
-      merged.defaultCoseNodeRepulsion = stored.defaultCoseNodeRepulsion !== undefined ? Number(stored.defaultCoseNodeRepulsion) : defaults.defaultCoseNodeRepulsion
-      merged.defaultCoseIdealEdgeLength = stored.defaultCoseIdealEdgeLength !== undefined ? Number(stored.defaultCoseIdealEdgeLength) : defaults.defaultCoseIdealEdgeLength
-      merged.defaultCoseGravity = stored.defaultCoseGravity !== undefined ? Number(stored.defaultCoseGravity) : defaults.defaultCoseGravity
-      merged.defaultCoseNodeOverlap = stored.defaultCoseNodeOverlap !== undefined ? Number(stored.defaultCoseNodeOverlap) : defaults.defaultCoseNodeOverlap
-      merged.defaultBreadthfirstDirected = stored.defaultBreadthfirstDirected !== undefined ? Boolean(stored.defaultBreadthfirstDirected) : defaults.defaultBreadthfirstDirected
-      merged.defaultBreadthfirstCircle = stored.defaultBreadthfirstCircle !== undefined ? Boolean(stored.defaultBreadthfirstCircle) : defaults.defaultBreadthfirstCircle
-      merged.defaultBreadthfirstSpacingFactor = stored.defaultBreadthfirstSpacingFactor !== undefined ? Number(stored.defaultBreadthfirstSpacingFactor) : defaults.defaultBreadthfirstSpacingFactor
-      merged.defaultGridRows = stored.defaultGridRows != null ? Number(stored.defaultGridRows) : defaults.defaultGridRows
-      merged.defaultGridCols = stored.defaultGridCols != null ? Number(stored.defaultGridCols) : defaults.defaultGridCols
-      merged.defaultGridAvoidOverlap = stored.defaultGridAvoidOverlap !== undefined ? Boolean(stored.defaultGridAvoidOverlap) : defaults.defaultGridAvoidOverlap
-      merged.defaultGridSpacingFactor = stored.defaultGridSpacingFactor !== undefined ? Number(stored.defaultGridSpacingFactor) : defaults.defaultGridSpacingFactor
-      merged.defaultCircleSpacingFactor = stored.defaultCircleSpacingFactor !== undefined ? Number(stored.defaultCircleSpacingFactor) : defaults.defaultCircleSpacingFactor
-      merged.defaultCircleClockwise = stored.defaultCircleClockwise !== undefined ? Boolean(stored.defaultCircleClockwise) : defaults.defaultCircleClockwise
-      merged.defaultConcentricSpacingFactor = stored.defaultConcentricSpacingFactor !== undefined ? Number(stored.defaultConcentricSpacingFactor) : defaults.defaultConcentricSpacingFactor
-      merged.defaultConcentricMinNodeSpacing = stored.defaultConcentricMinNodeSpacing !== undefined ? Number(stored.defaultConcentricMinNodeSpacing) : defaults.defaultConcentricMinNodeSpacing
-      merged.defaultConcentricClockwise = stored.defaultConcentricClockwise !== undefined ? Boolean(stored.defaultConcentricClockwise) : defaults.defaultConcentricClockwise
-      merged.defaultConcentricEquidistant = stored.defaultConcentricEquidistant !== undefined ? Boolean(stored.defaultConcentricEquidistant) : defaults.defaultConcentricEquidistant
+      merged.defaultColaEdgeLength =
+        stored.defaultColaEdgeLength !== undefined
+          ? Number(stored.defaultColaEdgeLength)
+          : defaults.defaultColaEdgeLength
+      merged.defaultColaNodeSpacing =
+        stored.defaultColaNodeSpacing !== undefined
+          ? Number(stored.defaultColaNodeSpacing)
+          : defaults.defaultColaNodeSpacing
+      merged.defaultColaFlow =
+        stored.defaultColaFlow !== undefined ? stored.defaultColaFlow : defaults.defaultColaFlow
+      merged.defaultColaAvoidOverlap =
+        stored.defaultColaAvoidOverlap !== undefined
+          ? Boolean(stored.defaultColaAvoidOverlap)
+          : defaults.defaultColaAvoidOverlap
+      merged.defaultColaMaxSimulationTime =
+        stored.defaultColaMaxSimulationTime !== undefined
+          ? Number(stored.defaultColaMaxSimulationTime)
+          : defaults.defaultColaMaxSimulationTime
+      merged.defaultColaGravity =
+        stored.defaultColaGravity !== undefined
+          ? Number(stored.defaultColaGravity)
+          : defaults.defaultColaGravity
+      merged.defaultCoseNodeRepulsion =
+        stored.defaultCoseNodeRepulsion !== undefined
+          ? Number(stored.defaultCoseNodeRepulsion)
+          : defaults.defaultCoseNodeRepulsion
+      merged.defaultCoseIdealEdgeLength =
+        stored.defaultCoseIdealEdgeLength !== undefined
+          ? Number(stored.defaultCoseIdealEdgeLength)
+          : defaults.defaultCoseIdealEdgeLength
+      merged.defaultCoseGravity =
+        stored.defaultCoseGravity !== undefined
+          ? Number(stored.defaultCoseGravity)
+          : defaults.defaultCoseGravity
+      merged.defaultCoseNodeOverlap =
+        stored.defaultCoseNodeOverlap !== undefined
+          ? Number(stored.defaultCoseNodeOverlap)
+          : defaults.defaultCoseNodeOverlap
+      merged.defaultBreadthfirstDirected =
+        stored.defaultBreadthfirstDirected !== undefined
+          ? Boolean(stored.defaultBreadthfirstDirected)
+          : defaults.defaultBreadthfirstDirected
+      merged.defaultBreadthfirstCircle =
+        stored.defaultBreadthfirstCircle !== undefined
+          ? Boolean(stored.defaultBreadthfirstCircle)
+          : defaults.defaultBreadthfirstCircle
+      merged.defaultBreadthfirstSpacingFactor =
+        stored.defaultBreadthfirstSpacingFactor !== undefined
+          ? Number(stored.defaultBreadthfirstSpacingFactor)
+          : defaults.defaultBreadthfirstSpacingFactor
+      merged.defaultGridRows =
+        stored.defaultGridRows != null ? Number(stored.defaultGridRows) : defaults.defaultGridRows
+      merged.defaultGridCols =
+        stored.defaultGridCols != null ? Number(stored.defaultGridCols) : defaults.defaultGridCols
+      merged.defaultGridAvoidOverlap =
+        stored.defaultGridAvoidOverlap !== undefined
+          ? Boolean(stored.defaultGridAvoidOverlap)
+          : defaults.defaultGridAvoidOverlap
+      merged.defaultGridSpacingFactor =
+        stored.defaultGridSpacingFactor !== undefined
+          ? Number(stored.defaultGridSpacingFactor)
+          : defaults.defaultGridSpacingFactor
+      merged.defaultCircleSpacingFactor =
+        stored.defaultCircleSpacingFactor !== undefined
+          ? Number(stored.defaultCircleSpacingFactor)
+          : defaults.defaultCircleSpacingFactor
+      merged.defaultCircleClockwise =
+        stored.defaultCircleClockwise !== undefined
+          ? Boolean(stored.defaultCircleClockwise)
+          : defaults.defaultCircleClockwise
+      merged.defaultConcentricSpacingFactor =
+        stored.defaultConcentricSpacingFactor !== undefined
+          ? Number(stored.defaultConcentricSpacingFactor)
+          : defaults.defaultConcentricSpacingFactor
+      merged.defaultConcentricMinNodeSpacing =
+        stored.defaultConcentricMinNodeSpacing !== undefined
+          ? Number(stored.defaultConcentricMinNodeSpacing)
+          : defaults.defaultConcentricMinNodeSpacing
+      merged.defaultConcentricClockwise =
+        stored.defaultConcentricClockwise !== undefined
+          ? Boolean(stored.defaultConcentricClockwise)
+          : defaults.defaultConcentricClockwise
+      merged.defaultConcentricEquidistant =
+        stored.defaultConcentricEquidistant !== undefined
+          ? Boolean(stored.defaultConcentricEquidistant)
+          : defaults.defaultConcentricEquidistant
       merged.defaultDagreRankDir = stored.defaultDagreRankDir || defaults.defaultDagreRankDir
-      merged.defaultDagreNodeSep = stored.defaultDagreNodeSep !== undefined ? Number(stored.defaultDagreNodeSep) : defaults.defaultDagreNodeSep
-      merged.defaultDagreRankSep = stored.defaultDagreRankSep !== undefined ? Number(stored.defaultDagreRankSep) : defaults.defaultDagreRankSep
-      merged.defaultDagreEdgeSep = stored.defaultDagreEdgeSep !== undefined ? Number(stored.defaultDagreEdgeSep) : defaults.defaultDagreEdgeSep
+      merged.defaultDagreNodeSep =
+        stored.defaultDagreNodeSep !== undefined
+          ? Number(stored.defaultDagreNodeSep)
+          : defaults.defaultDagreNodeSep
+      merged.defaultDagreRankSep =
+        stored.defaultDagreRankSep !== undefined
+          ? Number(stored.defaultDagreRankSep)
+          : defaults.defaultDagreRankSep
+      merged.defaultDagreEdgeSep =
+        stored.defaultDagreEdgeSep !== undefined
+          ? Number(stored.defaultDagreEdgeSep)
+          : defaults.defaultDagreEdgeSep
       merged.defaultDagreRanker = stored.defaultDagreRanker || defaults.defaultDagreRanker
-      merged.defaultEdgeStyle = stored.defaultEdgeStyle === 'curved'
-        ? 'bezier'
-        : (stored.defaultEdgeStyle || defaults.defaultEdgeStyle)
-      merged.defaultEdgeWidth = stored.defaultEdgeWidth !== undefined ? Number(stored.defaultEdgeWidth) : defaults.defaultEdgeWidth
-      merged.defaultEdgeOpacity = stored.defaultEdgeOpacity !== undefined ? Number(stored.defaultEdgeOpacity) : defaults.defaultEdgeOpacity
-      merged.defaultArrowScale = Math.min(3, Math.max(0.1, stored.defaultArrowScale !== undefined ? Number(stored.defaultArrowScale) : defaults.defaultArrowScale))
+      merged.defaultEdgeStyle =
+        stored.defaultEdgeStyle === 'curved'
+          ? 'bezier'
+          : stored.defaultEdgeStyle || defaults.defaultEdgeStyle
+      merged.defaultEdgeWidth =
+        stored.defaultEdgeWidth !== undefined
+          ? Number(stored.defaultEdgeWidth)
+          : defaults.defaultEdgeWidth
+      merged.defaultEdgeOpacity =
+        stored.defaultEdgeOpacity !== undefined
+          ? Number(stored.defaultEdgeOpacity)
+          : defaults.defaultEdgeOpacity
+      merged.defaultArrowScale = Math.min(
+        3,
+        Math.max(
+          0.1,
+          stored.defaultArrowScale !== undefined
+            ? Number(stored.defaultArrowScale)
+            : defaults.defaultArrowScale
+        )
+      )
       merged.defaultArrowShape = stored.defaultArrowShape || defaults.defaultArrowShape
-      merged.defaultEdgeArrowHeadStyle = stored.defaultEdgeArrowHeadStyle || defaults.defaultEdgeArrowHeadStyle
-      merged.defaultEdgeSourceArrow = stored.defaultEdgeSourceArrow || defaults.defaultEdgeSourceArrow
+      merged.defaultEdgeArrowHeadStyle =
+        stored.defaultEdgeArrowHeadStyle || defaults.defaultEdgeArrowHeadStyle
+      merged.defaultEdgeSourceArrow =
+        stored.defaultEdgeSourceArrow || defaults.defaultEdgeSourceArrow
       merged.defaultEdgeColor = stored.defaultEdgeColor || defaults.defaultEdgeColor
       merged.defaultEdgeLineStyle = stored.defaultEdgeLineStyle || defaults.defaultEdgeLineStyle
       merged.defaultNodeShape = stored.defaultNodeShape || defaults.defaultNodeShape
       merged.defaultNodeTextHalign = stored.defaultNodeTextHalign || defaults.defaultNodeTextHalign
       merged.defaultNodeTextValign = stored.defaultNodeTextValign || defaults.defaultNodeTextValign
       merged.defaultNodeBgColor = stored.defaultNodeBgColor || defaults.defaultNodeBgColor
-      merged.defaultNodeBorderColor = stored.defaultNodeBorderColor || defaults.defaultNodeBorderColor
-      merged.defaultNodeBorderWidth = stored.defaultNodeBorderWidth != null ? Number(stored.defaultNodeBorderWidth) : defaults.defaultNodeBorderWidth
-      merged.defaultNodeFontSize = stored.defaultNodeFontSize != null ? Number(stored.defaultNodeFontSize) : defaults.defaultNodeFontSize
-      merged.defaultNodeLabel = stored.defaultNodeLabel !== undefined ? stored.defaultNodeLabel : defaults.defaultNodeLabel
-      merged.defaultEdgeLabel = stored.defaultEdgeLabel !== undefined ? stored.defaultEdgeLabel : defaults.defaultEdgeLabel
+      merged.defaultNodeBorderColor =
+        stored.defaultNodeBorderColor || defaults.defaultNodeBorderColor
+      merged.defaultNodeBorderWidth =
+        stored.defaultNodeBorderWidth != null
+          ? Number(stored.defaultNodeBorderWidth)
+          : defaults.defaultNodeBorderWidth
+      merged.defaultNodeFontSize =
+        stored.defaultNodeFontSize != null
+          ? Number(stored.defaultNodeFontSize)
+          : defaults.defaultNodeFontSize
+      merged.defaultNodeLabel =
+        stored.defaultNodeLabel !== undefined ? stored.defaultNodeLabel : defaults.defaultNodeLabel
+      merged.defaultEdgeLabel =
+        stored.defaultEdgeLabel !== undefined ? stored.defaultEdgeLabel : defaults.defaultEdgeLabel
       merged.serverUrl = stored.serverUrl || defaults.serverUrl
       return merged
     },
-    expandHex (value) {
+    expandHex(value) {
       if (typeof value !== 'string') return value
       const match = /^#([0-9a-fA-F]{3})$/.exec(value.trim())
       if (!match) return value
       const hex = match[1]
       return '#' + hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2]
     },
-    close () {
+    close() {
       this.common()
     },
-    save () {
+    save() {
       this.$cookies.set('settings', this.settings)
       this.emitter.emit('settingsChanged')
-      this.emitter.emit('appMessage', {status: 'success', message: 'Settings saved'})
+      this.emitter.emit('appMessage', { status: 'success', message: 'Settings saved' })
       this.common()
     },
-    resetSettings () {
+    resetSettings() {
       const defaults = this.cloneDefaults()
       this.settings = defaults
       this.$cookies.set('settings', defaults)
     },
-    common () {
+    common() {
       this.settingsModal = false
       this.emitter.emit('changeActive')
-    },
-  },
+    }
+  }
 }
 </script>
 
@@ -1055,6 +1432,24 @@ export default {
   padding-left: 10px;
   border-left: 3px solid rgba(var(--fx-accent), 0.55);
   line-height: 1.3;
+}
+
+.fx-shortcut-group {
+  margin-top: 4px;
+}
+
+.fx-shortcut-group-title {
+  font-size: 10px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgb(var(--fx-ink-faint));
+  margin: 10px 0 2px;
+}
+
+.fx-shortcut-actions {
+  margin-top: 10px;
+  display: flex;
+  justify-content: flex-end;
 }
 
 .fx-toggle {
@@ -1102,7 +1497,9 @@ export default {
   border: 1px solid rgba(var(--fx-accent), 0.4);
   background: rgba(var(--fx-ink-faint), 0.2);
   position: relative;
-  transition: background 0.2s ease, border-color 0.2s ease;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease;
 }
 
 .fx-toggle input:checked + .fx-toggle-track {
@@ -1120,7 +1517,9 @@ export default {
   height: 14px;
   border-radius: 50%;
   background: rgb(var(--fx-ink));
-  transition: transform 0.2s ease, background 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    background 0.2s ease;
 }
 
 .fx-toggle input:checked + .fx-toggle-track::after {
@@ -1144,7 +1543,9 @@ export default {
   font-weight: 600;
   letter-spacing: 0.08em;
   cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease;
+  transition:
+    background 0.2s ease,
+    color 0.2s ease;
 }
 
 .fx-pill.is-active {

--- a/src/components/ShortcutRecorder.vue
+++ b/src/components/ShortcutRecorder.vue
@@ -1,0 +1,186 @@
+<template>
+  <div class="fx-shortcut">
+    <div class="fx-shortcut-main">
+      <span class="fx-shortcut-label">{{ label }}</span>
+      <button
+        v-if="!recording"
+        type="button"
+        class="fx-shortcut-combo"
+        :title="'Press to change ' + label"
+        @click="startRecord"
+      >
+        <span class="fx-kbd">{{ display }}</span>
+        <span class="fx-shortcut-action">change</span>
+      </button>
+      <button
+        v-else
+        type="button"
+        class="fx-shortcut-combo is-recording"
+        @keydown="captureKeydown"
+        @blur="stopRecord"
+      >
+        <span class="fx-shortcut-pulse">Press keys…</span>
+      </button>
+      <button
+        v-if="!recording && isCustom"
+        type="button"
+        class="fx-btn-mini fx-shortcut-reset"
+        @click="reset"
+      >
+        reset
+      </button>
+    </div>
+    <div v-if="messages.length" class="fx-shortcut-warn">
+      <span v-for="msg in messages" :key="msg" class="fx-shortcut-msg">{{ msg }}</span>
+    </div>
+  </div>
+</template>
+
+<script>
+import Shortcuts from '@/helpers/Shortcuts.js'
+
+export default {
+  name: 'ShortcutRecorder',
+  props: {
+    // The stored override for this action (undefined when using the default).
+    modelValue: { type: String, default: null },
+    actionId: { type: String, required: true },
+    label: { type: String, required: true },
+    // Action ids that currently share this combo (conflict detection).
+    conflictIds: { type: Array, default: () => [] }
+  },
+  emits: ['update:modelValue'],
+  data() {
+    return { recording: false }
+  },
+  computed: {
+    defaultCombo() {
+      const entry = Shortcuts.action(this.actionId)
+      if (!entry) return ''
+      return Shortcuts.isMac() ? entry.mac : entry.other
+    },
+    effectiveCombo() {
+      return this.modelValue || this.defaultCombo
+    },
+    display() {
+      return Shortcuts.format(this.effectiveCombo)
+    },
+    isCustom() {
+      return !!this.modelValue && this.modelValue !== this.defaultCombo
+    },
+    messages() {
+      const out = []
+      const validation = Shortcuts.validate(this.effectiveCombo)
+      if (!validation.ok) out.push(validation.reasons[0])
+      else out.push(...validation.reasons)
+      const conflicts = this.conflictIds.filter((id) => id !== this.actionId)
+      if (conflicts.length) {
+        const names = conflicts.map((id) => Shortcuts.action(id)?.label || id).join(', ')
+        out.push(`Also assigned to: ${names}`)
+      }
+      return out
+    }
+  },
+  beforeUnmount() {
+    this.stopRecord()
+  },
+  methods: {
+    startRecord() {
+      this.recording = true
+      window.addEventListener('keydown', this.captureKeydown, true)
+    },
+    stopRecord() {
+      if (!this.recording) return
+      this.recording = false
+      window.removeEventListener('keydown', this.captureKeydown, true)
+    },
+    captureKeydown(event) {
+      event.preventDefault()
+      event.stopPropagation()
+      if (event.key === 'Escape') {
+        this.stopRecord()
+        return
+      }
+      const combo = Shortcuts.comboFromEvent(event)
+      if (!combo) return
+      this.$emit('update:modelValue', combo)
+      this.stopRecord()
+    },
+    reset() {
+      this.$emit('update:modelValue', null)
+    }
+  }
+}
+</script>
+
+<style scoped>
+.fx-shortcut {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 0;
+  border-bottom: 1px solid rgba(var(--fx-accent), 0.08);
+}
+
+.fx-shortcut-main {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.fx-shortcut-label {
+  flex: 1;
+  min-width: 0;
+  font-size: 12px;
+  color: rgb(var(--fx-ink));
+}
+
+.fx-shortcut-combo {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font: inherit;
+}
+
+.fx-shortcut-combo.is-recording {
+  padding: 4px 10px;
+  border: 1px dashed rgb(var(--fx-accent));
+  border-radius: 4px;
+  cursor: default;
+}
+
+.fx-shortcut-pulse {
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgb(var(--fx-accent));
+}
+
+.fx-shortcut-action {
+  font-size: 10px;
+  color: rgb(var(--fx-ink-faint));
+  text-decoration: underline dotted;
+}
+
+.fx-shortcut-reset {
+  flex: none;
+  font-size: 10px;
+  padding: 4px 8px;
+  color: rgb(var(--fx-ink-dim));
+}
+
+.fx-shortcut-warn {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.fx-shortcut-msg {
+  font-size: 10px;
+  color: rgb(var(--fx-warn, 220, 160, 60));
+}
+</style>

--- a/src/helpers/D3Util.js
+++ b/src/helpers/D3Util.js
@@ -1,26 +1,23 @@
 import VueCookies from 'vue-cookies'
 import { modelToGraphlib } from '@/helpers/graphlibMigration'
+import Shortcuts from '@/helpers/Shortcuts.js'
 
 /*need to doublecheck if the vars below are the best way to do the zooming*/
 
 export default {
-  isMac () {
-    if (typeof navigator === 'undefined') return false
-    const platform = navigator.platform || navigator.userAgentData?.platform || ''
-    return platform.toLowerCase().includes('mac') ||
-      /Mac|iPhone|iPad/.test(navigator.userAgent)
+  isMac() {
+    return Shortcuts.isMac()
   },
-  shortcutLabels () {
-    const saveKey  = this.isMac() ? '⌘' : 'Alt'
-    const closeKey = this.isMac() ? '⌘' : 'Ctrl'
+  shortcutLabels() {
+    // Live labels from the user-rebindable shortcut registry.
     return {
-      save:  `${saveKey}+S`,
-      close: `${closeKey}+C`,
-      login: `${saveKey}+L`,
-      clear: `${saveKey}+Shift+W`,
+      save: Shortcuts.label('save'),
+      close: Shortcuts.label('close'),
+      login: Shortcuts.label('login'),
+      clear: Shortcuts.label('clear')
     }
   },
-  tempInfo () {
+  tempInfo() {
     let temp = {
       name: 'D3D Temp Name',
       description: 'My Awesome Diagram'
@@ -29,14 +26,14 @@ export default {
   },
   //getDiagram(diagramId) {
   //},
-  getLiElements () {
+  getLiElements() {
     var lis = document.getElementsByTagName('li')
     return lis
   },
-  mod (n, m) {
+  mod(n, m) {
     return ((n % m) + m) % m
   },
-  filteredKeys (hints, filter) {
+  filteredKeys(hints, filter) {
     var hintsCopy = hints
     var key = []
     var keys = {}
@@ -65,7 +62,7 @@ export default {
 
     return filterData
   },
-  liSelectionK (selectList, liSelected) {
+  liSelectionK(selectList, liSelected) {
     var li = liSelected
     var selectLi = null
     if (li === null) {
@@ -77,7 +74,7 @@ export default {
     }
     return selectLi
   },
-  liSelectionJ (selectList, liSelected) {
+  liSelectionJ(selectList, liSelected) {
     var li = liSelected
     var selectLi = null
     if (li === null) {
@@ -88,180 +85,183 @@ export default {
     }
     return selectLi
   },
-  debug () {
+  debug() {
     //how the hell was this working, if it was working?
     //I think we need to pull if from settings cookie
     //var debug = Settings.debug
     let debug = true
     return debug
   },
-  hintOptions () {
+  hintOptions() {
     // Need to get from database or a cookie
     var hintOptions = VueCookies.get('settings')
-    if ( hintOptions ) {
+    if (hintOptions) {
       return hintOptions['hints']
     } else {
       console.log('cookie settings is missing')
     }
   },
-  randomId () {
-  // Math.random should be unique because of its seeding algorithm.
-  // Convert it to base 36 (numbers + letters), and grab the first 9 characters
-  // after the decimal.
+  randomId() {
+    // Math.random should be unique because of its seeding algorithm.
+    // Convert it to base 36 (numbers + letters), and grab the first 9 characters
+    // after the decimal.
     return '_' + Math.random().toString(36).substr(2, 9)
   },
   // Shared dropdown option lists. Single source of truth so the Settings
   // dialog and the node/edge forms cannot drift apart.
-  nodeShapeOptions () {
+  nodeShapeOptions() {
     return [
-      { value: 'rectangle',       label: 'Rectangle' },
+      { value: 'rectangle', label: 'Rectangle' },
       { value: 'round-rectangle', label: 'Round Rectangle' },
-      { value: 'ellipse',         label: 'Ellipse' },
-      { value: 'diamond',         label: 'Diamond' },
-      { value: 'round-diamond',   label: 'Round Diamond' },
-      { value: 'hexagon',         label: 'Hexagon' },
-      { value: 'octagon',         label: 'Octagon' },
-      { value: 'star',            label: 'Star' },
-      { value: 'tag',             label: 'Tag' },
-      { value: 'barrel',          label: 'Barrel' },
+      { value: 'ellipse', label: 'Ellipse' },
+      { value: 'diamond', label: 'Diamond' },
+      { value: 'round-diamond', label: 'Round Diamond' },
+      { value: 'hexagon', label: 'Hexagon' },
+      { value: 'octagon', label: 'Octagon' },
+      { value: 'star', label: 'Star' },
+      { value: 'tag', label: 'Tag' },
+      { value: 'barrel', label: 'Barrel' }
     ]
   },
-  nodeHalignOptions () {
+  nodeHalignOptions() {
     return [
-      { value: 'left',   label: 'Left' },
+      { value: 'left', label: 'Left' },
       { value: 'center', label: 'Center' },
-      { value: 'right',  label: 'Right' },
+      { value: 'right', label: 'Right' }
     ]
   },
-  nodeValignOptions () {
+  nodeValignOptions() {
     return [
-      { value: 'top',    label: 'Top' },
+      { value: 'top', label: 'Top' },
       { value: 'center', label: 'Center' },
-      { value: 'bottom', label: 'Bottom' },
+      { value: 'bottom', label: 'Bottom' }
     ]
   },
-  edgeArrowHeadStyleOptions () {
+  edgeArrowHeadStyleOptions() {
     return [
       { value: 'filled', label: 'Filled' },
-      { value: 'hollow', label: 'Hollow' },
+      { value: 'hollow', label: 'Hollow' }
     ]
   },
-  edgeArrowHeadOptions () {
+  edgeArrowHeadOptions() {
     return [
-      { value: 'triangle',       label: 'Triangle' },
-      { value: 'vee',            label: 'Vee' },
-      { value: 'none',           label: 'None (undirected)' },
-      { value: 'chevron',        label: 'Chevron' },
-      { value: 'tee',            label: 'Tee' },
-      { value: 'circle',         label: 'Circle' },
-      { value: 'diamond',        label: 'Diamond' },
-      { value: 'square',         label: 'Square' },
-      { value: 'triangle-tee',   label: 'Triangle Tee' },
-      { value: 'triangle-cross', label: 'Triangle Cross' },
+      { value: 'triangle', label: 'Triangle' },
+      { value: 'vee', label: 'Vee' },
+      { value: 'none', label: 'None (undirected)' },
+      { value: 'chevron', label: 'Chevron' },
+      { value: 'tee', label: 'Tee' },
+      { value: 'circle', label: 'Circle' },
+      { value: 'diamond', label: 'Diamond' },
+      { value: 'square', label: 'Square' },
+      { value: 'triangle-tee', label: 'Triangle Tee' },
+      { value: 'triangle-cross', label: 'Triangle Cross' }
     ]
   },
-  edgeLineStyleOptions () {
+  edgeLineStyleOptions() {
     return [
-      { value: 'solid',   label: 'Solid' },
-      { value: 'dotted',  label: 'Dotted' },
-      { value: 'dashed',  label: 'Dashed' },
+      { value: 'solid', label: 'Solid' },
+      { value: 'dotted', label: 'Dotted' },
+      { value: 'dashed', label: 'Dashed' }
     ]
   },
-  edgeCurveOptions () {
+  edgeCurveOptions() {
     return [
-      { value: 'bezier',           label: 'Bezier' },
-      { value: 'straight',         label: 'Straight' },
-      { value: 'segmented',        label: 'Segmented' },
+      { value: 'bezier', label: 'Bezier' },
+      { value: 'straight', label: 'Straight' },
+      { value: 'segmented', label: 'Segmented' },
       { value: 'unbundled-bezier', label: 'Unbundled Bezier' },
-      { value: 'haystack',         label: 'Haystack' },
+      { value: 'haystack', label: 'Haystack' }
     ]
   },
-  layoutOptions () {
+  layoutOptions() {
     return [
-      { value: 'cola',         label: 'Cola (Physics-based)' },
-      { value: 'cose',         label: 'CoSE (Force-directed)' },
+      { value: 'cola', label: 'Cola (Physics-based)' },
+      { value: 'cose', label: 'CoSE (Force-directed)' },
       { value: 'breadthfirst', label: 'Breadth First (Tree)' },
-      { value: 'grid',         label: 'Grid' },
-      { value: 'circle',       label: 'Circle' },
-      { value: 'concentric',   label: 'Concentric' },
-      { value: 'dagre',        label: 'Dagre (Hierarchical)' },
-      { value: 'random',       label: 'Random' },
+      { value: 'grid', label: 'Grid' },
+      { value: 'circle', label: 'Circle' },
+      { value: 'concentric', label: 'Concentric' },
+      { value: 'dagre', label: 'Dagre (Hierarchical)' },
+      { value: 'random', label: 'Random' }
     ]
   },
-  appDefaults () { 
+  appDefaults() {
     var defaults = {
-      'hintBGColor': '#36004c',
-      'hintLinkColor': '#ffffff', 
-      'debug': false, 
-      'hints': 'asdfjklqweruiopzxcvnmgh', 
-      'reset': false,
-      'showHelpPane': true,
-      'd3dInfo': false,
-      'hintAction': 'Edit Object',
-      'defaultTheme': 'light',
-      'themes': [
-        {'value':'light', 'label':'Light Theme'},
-        {'value':'dark', 'label':'Dark Theme'},
+      hintBGColor: '#36004c',
+      hintLinkColor: '#ffffff',
+      debug: false,
+      hints: 'asdfjklqweruiopzxcvnmgh',
+      reset: false,
+      showHelpPane: true,
+      d3dInfo: false,
+      hintAction: 'Edit Object',
+      defaultTheme: 'light',
+      themes: [
+        { value: 'light', label: 'Light Theme' },
+        { value: 'dark', label: 'Dark Theme' }
       ],
-      'zoomFitFactor': 60,
-      'defaultZoomFit': true,
-      'defaultZoomLevel': 1,
-      'defaultLayoutMode': 'cola',
-      'defaultColaEdgeLength': 120,
-      'defaultColaNodeSpacing': 30,
-      'defaultColaFlow': null,
-      'defaultColaAvoidOverlap': true,
-      'defaultColaMaxSimulationTime': 1500,
-      'defaultColaGravity': 0,
-      'defaultCoseNodeRepulsion': 400000,
-      'defaultCoseIdealEdgeLength': 100,
-      'defaultCoseGravity': 1,
-      'defaultCoseNodeOverlap': 4,
-      'defaultBreadthfirstDirected': true,
-      'defaultBreadthfirstCircle': false,
-      'defaultBreadthfirstSpacingFactor': 1.5,
-      'defaultGridRows': null,
-      'defaultGridCols': null,
-      'defaultGridAvoidOverlap': true,
-      'defaultGridSpacingFactor': 1.5,
-      'defaultCircleSpacingFactor': 1.0,
-      'defaultCircleClockwise': true,
-      'defaultConcentricSpacingFactor': 1.5,
-      'defaultConcentricMinNodeSpacing': 30,
-      'defaultConcentricClockwise': true,
-      'defaultConcentricEquidistant': false,
-      'defaultDagreRankDir': 'TB',
-      'defaultDagreNodeSep': 50,
-      'defaultDagreRankSep': 50,
-      'defaultDagreEdgeSep': 10,
-      'defaultDagreRanker': 'network-simplex',
-      'defaultEdgeStyle': 'bezier',
-      'defaultEdgeWidth': 2,
-      'defaultEdgeOpacity': 0.85,
-      'defaultArrowScale': 1,
-      'defaultArrowShape': 'vee',
-      'defaultEdgeArrowHeadStyle': 'filled',
-      'defaultEdgeSourceArrow': '',
-      'defaultEdgeColor': '',
-      'defaultEdgeLineStyle': 'solid',
-      'defaultNodeLabel': '',
-      'defaultNodeShape': 'rectangle',
-      'defaultNodeTextHalign': 'center',
-      'defaultNodeTextValign': 'top',
-      'defaultNodeBgColor': '',
-      'defaultNodeBorderColor': '',
-      'defaultNodeBorderWidth': null,
-      'defaultNodeFontSize': null,
-      'defaultEdgeLabel': '',
-      'serverUrl': 'http://localhost:3000',
+      zoomFitFactor: 60,
+      defaultZoomFit: true,
+      defaultZoomLevel: 1,
+      defaultLayoutMode: 'cola',
+      defaultColaEdgeLength: 120,
+      defaultColaNodeSpacing: 30,
+      defaultColaFlow: null,
+      defaultColaAvoidOverlap: true,
+      defaultColaMaxSimulationTime: 1500,
+      defaultColaGravity: 0,
+      defaultCoseNodeRepulsion: 400000,
+      defaultCoseIdealEdgeLength: 100,
+      defaultCoseGravity: 1,
+      defaultCoseNodeOverlap: 4,
+      defaultBreadthfirstDirected: true,
+      defaultBreadthfirstCircle: false,
+      defaultBreadthfirstSpacingFactor: 1.5,
+      defaultGridRows: null,
+      defaultGridCols: null,
+      defaultGridAvoidOverlap: true,
+      defaultGridSpacingFactor: 1.5,
+      defaultCircleSpacingFactor: 1.0,
+      defaultCircleClockwise: true,
+      defaultConcentricSpacingFactor: 1.5,
+      defaultConcentricMinNodeSpacing: 30,
+      defaultConcentricClockwise: true,
+      defaultConcentricEquidistant: false,
+      defaultDagreRankDir: 'TB',
+      defaultDagreNodeSep: 50,
+      defaultDagreRankSep: 50,
+      defaultDagreEdgeSep: 10,
+      defaultDagreRanker: 'network-simplex',
+      defaultEdgeStyle: 'bezier',
+      defaultEdgeWidth: 2,
+      defaultEdgeOpacity: 0.85,
+      defaultArrowScale: 1,
+      defaultArrowShape: 'vee',
+      defaultEdgeArrowHeadStyle: 'filled',
+      defaultEdgeSourceArrow: '',
+      defaultEdgeColor: '',
+      defaultEdgeLineStyle: 'solid',
+      defaultNodeLabel: '',
+      defaultNodeShape: 'rectangle',
+      defaultNodeTextHalign: 'center',
+      defaultNodeTextValign: 'top',
+      defaultNodeBgColor: '',
+      defaultNodeBorderColor: '',
+      defaultNodeBorderWidth: null,
+      defaultNodeFontSize: null,
+      defaultEdgeLabel: '',
+      serverUrl: 'http://localhost:3000',
+      // User-rebindable shortcut overrides (id → combo). Defaults live in
+      // Shortcuts.DEFAULT_SHORTCUTS; an empty object means all defaults.
+      shortcuts: {}
     }
     return defaults
   },
-  serverUrl () {
+  serverUrl() {
     const s = VueCookies.get('settings')
-    return (s && s.serverUrl) ? s.serverUrl : 'http://localhost:3000'
+    return s && s.serverUrl ? s.serverUrl : 'http://localhost:3000'
   },
-  buildHints (elements, hyperLinks=false) {
+  buildHints(elements, hyperLinks = false) {
     var hints = {}
     var shortcutOptions = this.hintOptions()
     var shortcutLength = shortcutOptions.length
@@ -288,11 +288,21 @@ export default {
       div.innerHTML = shortcut
       if (elements[i].type === 'text') {
         console.log('am i here type text')
-        div.style.cssText = 'display: table-caption; color: '+hintLinkColor+'; border: 1px solid #36004c; padding: 1px 8px 1px 8px; border-radius: 10px; background: '+hintBGColor+'; z-index: 1; position: absolute'
+        div.style.cssText =
+          'display: table-caption; color: ' +
+          hintLinkColor +
+          '; border: 1px solid #36004c; padding: 1px 8px 1px 8px; border-radius: 10px; background: ' +
+          hintBGColor +
+          '; z-index: 1; position: absolute'
         elements[i].parentNode.append(div)
       } else {
         console.log('am i here type text else')
-        div.style.cssText = 'display: table-caption; color: '+hintLinkColor+'; border: 1px solid #36004c; padding: 1px 8px 1px 8px; border-radius: 10px; background: '+hintBGColor+'; z-index: 1; position: absolute'
+        div.style.cssText =
+          'display: table-caption; color: ' +
+          hintLinkColor +
+          '; border: 1px solid #36004c; padding: 1px 8px 1px 8px; border-radius: 10px; background: ' +
+          hintBGColor +
+          '; z-index: 1; position: absolute'
         /*Depending on what we are hinting on the parent is differnt*/
         if (hyperLinks) {
           elements[i].append(div)
@@ -310,11 +320,11 @@ export default {
 
     return hints
   },
-  selectionBool (index) {
+  selectionBool(index) {
     console.log(this.menuLinks[index].title)
     this.currentMenuLink = this.menuLinks[index].title
   },
-  d3FilterKeys (hints, filter, eventKey) {
+  d3FilterKeys(hints, filter, eventKey) {
     // var key = []
     var keys = {}
     var newHints = {}
@@ -353,18 +363,21 @@ export default {
 
     return filterData
   },
-  formHints (event, form){
-    if (this.debug){
+  formHints(event, form) {
+    if (this.debug) {
       console.log(event.key)
       console.log('form hints')
     }
 
     if (event.key === 'Escape') {
       console.log('escape')
-      this.removeHints(form.hints)
-      form.common()
-    } else if ((Object.keys(form.hints).length > 0) && (Object.prototype.hasOwnProperty.call(form.hints, event.key))) {
-
+      // Closing the form is handled by the form's own keydown handler via the
+      // user's configured 'close' shortcut — never assume Esc here.
+      return form.hints
+    } else if (
+      Object.keys(form.hints).length > 0 &&
+      Object.prototype.hasOwnProperty.call(form.hints, event.key)
+    ) {
       if (this.debug) {
         //console.log(form.hints[event.key])
       }
@@ -384,13 +397,13 @@ export default {
       if (Object.keys(form.hints).length === 1) {
         form.hints = {}
       }
-    } else if (event.key == "f" ){
+    } else if (event.key == 'f') {
       if (Object.keys(form.hints).length > 0) {
         console.log('hints already being displayed')
         this.removeHint(form.hints, event.key)
       } else {
         var inputs = form.$refs.formfields.$el.querySelectorAll('submit,input,textarea')
-        return form.hints = this.buildHints(inputs)
+        return (form.hints = this.buildHints(inputs))
         // this.addFollowLinks()
       }
       //  break
@@ -400,16 +413,16 @@ export default {
       //   break
       // default:
       //   console.log('default')
-    } 
+    }
     // This delete helps cleanup the remaining hints, without removing the form radio
     // object
     delete form.hints[event.key]
     return form.hints
   },
-  removeHint (hints, eventKey) {
+  removeHint(hints, eventKey) {
     hints[eventKey].parentElement.removeChild(hints[eventKey].parentElement.lastChild)
   },
-  removeHints (hints) {
+  removeHints(hints) {
     try {
       if (this.debug) {
         console.log(hints)
@@ -439,8 +452,7 @@ export default {
    * @param {integer} max number of items
    * @return {integer} a number
    **/
-  getIndex(index, key, items){
-
+  getIndex(index, key, items) {
     console.log(index)
     console.log(key)
     console.log(items)
@@ -448,21 +460,21 @@ export default {
     if (index === null || isNaN(index)) {
       id = 0
     } else {
-      switch(key){
+      switch (key) {
         case 'j':
           id = this.add(index)
           break
         case 'k':
-          id= this.remove(index)
+          id = this.remove(index)
       }
-        id = this.mod(id, items)
+      id = this.mod(id, items)
     }
 
     return id
   },
-  getPage(index, key, pages){
+  getPage(index, key, pages) {
     var id = null
-    switch(key){
+    switch (key) {
       case 'l':
         id = this.add(index)
         break
@@ -476,23 +488,23 @@ export default {
     }
     return id
   },
-  add(item){
+  add(item) {
     return item + 1
   },
-  remove(item){
+  remove(item) {
     return item - 1
   },
-  createLocalEntry(data){
-    try{
-      let randomId ='D3D'+this.randomId()
+  createLocalEntry(data) {
+    try {
+      let randomId = 'D3D' + this.randomId()
       let created = new Date()
       let json = modelToGraphlib(data.diagram)
-      let payload = { 
-        'name': data.name,
-        'description': data.description,
-        'diagram': JSON.stringify(json),
-        'created': created.toISOString(),
-        'updated': created.toISOString()
+      let payload = {
+        name: data.name,
+        description: data.description,
+        diagram: JSON.stringify(json),
+        created: created.toISOString(),
+        updated: created.toISOString()
       }
 
       localStorage.setItem(randomId, JSON.stringify(payload))
@@ -506,28 +518,27 @@ export default {
     try {
       // Check if the item with the given ID exists in localStorage
       if (localStorage.getItem(id) !== null) {
-          // Remove the item from localStorage
-          localStorage.removeItem(id);
-          console.log("Item with ID " + id + " has been removed from localStorage.");
+        // Remove the item from localStorage
+        localStorage.removeItem(id)
+        console.log('Item with ID ' + id + ' has been removed from localStorage.')
       } else {
-          console.log("Item with ID " + id + " does not exist in localStorage.");
+        console.log('Item with ID ' + id + ' does not exist in localStorage.')
       }
-
     } catch (error) {
       console.log(error)
     }
   },
-  updateLocalEntry(data){
-    try{
+  updateLocalEntry(data) {
+    try {
       console.log(data)
       let updated = new Date()
       let json = modelToGraphlib(data.diagram)
-      let payload = { 
-        'name': data.name,
-        'description': data.description,
-        'diagram': JSON.stringify(json),
-        'created': data.created,
-        'updated': updated.toISOString(),
+      let payload = {
+        name: data.name,
+        description: data.description,
+        diagram: JSON.stringify(json),
+        created: data.created,
+        updated: updated.toISOString()
       }
 
       localStorage.setItem(data.id, JSON.stringify(payload))
@@ -538,40 +549,39 @@ export default {
       console.log(error)
     }
   },
-  saveTempDiagram(cy){
+  saveTempDiagram(cy) {
     try {
       let json = modelToGraphlib(cy)
       let created = new Date()
       let updatedData = {
-        'created': created.toISOString(),
-        'updated': created.toISOString(),
-        'name': this.tempInfo().name,
-        'description': this.tempInfo().description,
-        'diagram': JSON.stringify(json),
+        created: created.toISOString(),
+        updated: created.toISOString(),
+        name: this.tempInfo().name,
+        description: this.tempInfo().description,
+        diagram: JSON.stringify(json)
       }
       localStorage.setItem('samus.lastUpdated', JSON.stringify(updatedData))
     } catch (error) {
       console.log('saveTempDiagram failed', error)
     }
   },
-  getTempDiagram(){
+  getTempDiagram() {
     var localData = JSON.parse(localStorage.getItem('samus.lastUpdated'))
     return localData
   },
-  getLocalItem(id){
+  getLocalItem(id) {
     let localItem = JSON.parse(localStorage.getItem(id))
     return localItem
-
   },
   //Need to check if token is valid
-  auth(){
-    if (localStorage.getItem('token')){
+  auth() {
+    if (localStorage.getItem('token')) {
       return true
     } else {
       return false
     }
   },
-  updateId(id){
+  updateId(id) {
     var localData = this.getLocal()
     console.log(localData)
     localData.id = id
@@ -581,36 +591,36 @@ export default {
   defaultNodeValues() {
     const s = this._readSettings()
     var data = {
-      nodeLabel:  s.defaultNodeLabel !== undefined ? s.defaultNodeLabel : '',
-      nodeShape:  s.defaultNodeShape       || 'rectangle',
-      textHalign: s.defaultNodeTextHalign  || 'center',
-      textValign: s.defaultNodeTextValign  || 'top',
-      bgColor:    s.defaultNodeBgColor     || '',
+      nodeLabel: s.defaultNodeLabel !== undefined ? s.defaultNodeLabel : '',
+      nodeShape: s.defaultNodeShape || 'rectangle',
+      textHalign: s.defaultNodeTextHalign || 'center',
+      textValign: s.defaultNodeTextValign || 'top',
+      bgColor: s.defaultNodeBgColor || '',
       borderColor: s.defaultNodeBorderColor || '',
       borderWidth: s.defaultNodeBorderWidth != null ? s.defaultNodeBorderWidth : null,
-      fontSize:   s.defaultNodeFontSize    != null ? s.defaultNodeFontSize : null,
+      fontSize: s.defaultNodeFontSize != null ? s.defaultNodeFontSize : null
     }
     return data
   },
   defaultEdgeValues() {
     const s = this._readSettings()
     var data = {
-      edgeLabel:          s.defaultEdgeLabel !== undefined ? s.defaultEdgeLabel : '',
+      edgeLabel: s.defaultEdgeLabel !== undefined ? s.defaultEdgeLabel : '',
       edgeArrowHeadStyle: s.defaultEdgeArrowHeadStyle || 'filled',
-      edgeArrowHead:      s.defaultArrowShape || 'vee',
-      sourceArrowhead:    s.defaultEdgeSourceArrow || '',
-      edgeWidth:          s.defaultEdgeWidth   != null ? Number(s.defaultEdgeWidth)   : 2,
-      edgeColor:          s.defaultEdgeColor   || '',
-      edgeLineStyle:      s.defaultEdgeLineStyle || 'solid',
-      edgeCurve:          this._normalizeEdgeCurve(s.defaultEdgeStyle),
-      edgeOpacity:        s.defaultEdgeOpacity != null ? Number(s.defaultEdgeOpacity) : 0.85,
+      edgeArrowHead: s.defaultArrowShape || 'vee',
+      sourceArrowhead: s.defaultEdgeSourceArrow || '',
+      edgeWidth: s.defaultEdgeWidth != null ? Number(s.defaultEdgeWidth) : 2,
+      edgeColor: s.defaultEdgeColor || '',
+      edgeLineStyle: s.defaultEdgeLineStyle || 'solid',
+      edgeCurve: this._normalizeEdgeCurve(s.defaultEdgeStyle),
+      edgeOpacity: s.defaultEdgeOpacity != null ? Number(s.defaultEdgeOpacity) : 0.85
     }
     return data
   },
   // Map the stored default curve value to a cytoscape curve-style. Legacy
   // settings saved 'curved' (label "Curved (Bezier)"); normalize it to the
   // cytoscape value 'bezier'.
-  _normalizeEdgeCurve (val) {
+  _normalizeEdgeCurve(val) {
     if (val === 'curved') return 'bezier'
     return val || 'bezier'
   },
@@ -622,5 +632,5 @@ export default {
     } catch (e) {
       return {}
     }
-  },
+  }
 }

--- a/src/helpers/D3Util.test.js
+++ b/src/helpers/D3Util.test.js
@@ -1,6 +1,7 @@
 /* eslint-env es2020 */
-import { describe, it, expect, afterEach, vi } from 'vitest'
+import { describe, it, expect, afterEach, vi, beforeEach } from 'vitest'
 import D3Util from '@/helpers/D3Util.js'
+import Shortcuts from '@/helpers/Shortcuts.js'
 
 vi.mock('vue-cookies', () => ({
   default: { get: vi.fn(() => null), set: vi.fn() }
@@ -42,19 +43,29 @@ describe('isMac', () => {
 })
 
 describe('shortcutLabels', () => {
+  beforeEach(() => {
+    vi.spyOn(Shortcuts, 'isMac').mockReturnValue(false)
+  })
+
   it('uses command labels on macOS', () => {
-    vi.spyOn(D3Util, 'isMac').mockReturnValue(true)
+    Shortcuts.isMac.mockReturnValue(true)
     const labels = D3Util.shortcutLabels()
-    expect(labels.save).toBe('⌘+S')
-    expect(labels.close).toBe('⌘+C')
+    expect(labels.save).toBe('⌘+Shift+S')
+    expect(labels.close).toBe('Esc')
     expect(labels.login).toBe('⌘+L')
   })
 
-  it('uses alt / ctrl labels elsewhere', () => {
-    vi.spyOn(D3Util, 'isMac').mockReturnValue(false)
+  it('uses alt labels elsewhere and esc to close', () => {
+    Shortcuts.isMac.mockReturnValue(false)
     const labels = D3Util.shortcutLabels()
-    expect(labels.save).toBe('Alt+S')
-    expect(labels.close).toBe('Ctrl+C')
+    expect(labels.save).toBe('Alt+Shift+S')
+    expect(labels.close).toBe('Esc')
+  })
+
+  it('reflects user shortcut rebinds', () => {
+    const spy = vi.spyOn(Shortcuts, 'overrides').mockReturnValue({ close: 'j' })
+    expect(D3Util.shortcutLabels().close).toBe('J')
+    spy.mockRestore()
   })
 })
 

--- a/src/helpers/GraphKeys.js
+++ b/src/helpers/GraphKeys.js
@@ -1,0 +1,58 @@
+import Shortcuts from '@/helpers/Shortcuts.js'
+
+// Resolves a graph-view keydown event to an action using the user's shortcut
+// bindings. Returns an action descriptor or null when the event does not
+// trigger any graph action. The caller (DiagramGraphView) owns state changes;
+// this module owns "which action fired".
+//
+// Action descriptors:
+//   { action: 'menu' | 'actionsMenu' | 'help' | 'toggleTheme' }
+//   { action: 'addNode' }                      { action: 'addEdge' }
+//   { action: 'edit', data, mode }             { action: 'delete' }
+//   { action: 'copy' }                         { action: 'history' }
+//   { action: 'close' }                        { action: 'select' }
+//   { action: 'nav', direction: 'j'|'k'|'h'|'l' }
+//   { action: 'showHints' }
+
+const NAV_DIRECTIONS = {
+  navDown: 'j',
+  navUp: 'k',
+  navLeft: 'h',
+  navRight: 'l'
+}
+
+export function resolveGraphKey(event, ctx) {
+  const { modifier, edgeOrNode, focusedNodeId, focusedEdgeId } = ctx
+  const S = Shortcuts
+
+  if (S.matches(event, 'menu')) return { action: 'menu' }
+  if (S.matches(event, 'actionsMenu')) return { action: 'actionsMenu' }
+  if (S.matches(event, 'help')) return { action: 'help' }
+  if (S.matches(event, 'toggleTheme')) return { action: 'toggleTheme' }
+  if (S.matches(event, 'addNode')) return { action: 'addNode' }
+  if (S.matches(event, 'addEdge')) return { action: 'addEdge' }
+
+  if (S.matches(event, 'editElement')) {
+    if (edgeOrNode === 'edges') {
+      if (!focusedEdgeId || !modifier) return null
+      return { action: 'edit', data: modifier.getEdgeData(focusedEdgeId), mode: 'Edit Edge' }
+    }
+    if (!focusedNodeId || !modifier) return null
+    return { action: 'edit', data: modifier.getNodeData(focusedNodeId), mode: 'Edit Node' }
+  }
+
+  if (S.matches(event, 'deleteElement')) return { action: 'delete' }
+  if (S.matches(event, 'copyNode')) return { action: 'copy' }
+  if (S.matches(event, 'history')) return { action: 'history' }
+  if (S.matches(event, 'close')) return { action: 'close' }
+  if (S.matches(event, 'select')) return { action: 'select' }
+  if (S.matches(event, 'showHints')) return { action: 'showHints' }
+
+  for (const [navId, direction] of Object.entries(NAV_DIRECTIONS)) {
+    if (S.matches(event, navId)) return { action: 'nav', direction }
+  }
+
+  return null
+}
+
+export default { resolve: resolveGraphKey }

--- a/src/helpers/GraphKeys.test.js
+++ b/src/helpers/GraphKeys.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { resolveGraphKey } from '@/helpers/GraphKeys.js'
+import Shortcuts from '@/helpers/Shortcuts.js'
+import VueCookies from 'vue-cookies'
+
+vi.mock('vue-cookies', () => ({
+  default: { get: vi.fn(), set: vi.fn() }
+}))
+
+function ev(key, mods = {}) {
+  return {
+    key,
+    metaKey: !!mods.meta,
+    ctrlKey: !!mods.ctrl,
+    altKey: !!mods.alt,
+    shiftKey: !!mods.shift
+  }
+}
+
+function ctx(overrides = {}) {
+  return {
+    modifier: {
+      getNodeData: vi.fn((id) => ({ id, label: 'n' })),
+      getEdgeData: vi.fn((id) => ({ id, label: 'e' }))
+    },
+    edgeOrNode: 'nodes',
+    focusedNodeId: 'n1',
+    focusedEdgeId: null,
+    ...overrides
+  }
+}
+
+beforeEach(() => {
+  vi.spyOn(Shortcuts, 'isMac').mockReturnValue(false)
+  VueCookies.get.mockReturnValue(null)
+})
+afterEach(() => vi.restoreAllMocks())
+
+describe('resolveGraphKey', () => {
+  it('resolves plain graph actions', () => {
+    expect(resolveGraphKey(ev('n'), ctx())).toEqual({ action: 'addNode' })
+    expect(resolveGraphKey(ev('d'), ctx())).toEqual({ action: 'addEdge' })
+    expect(resolveGraphKey(ev('x'), ctx())).toEqual({ action: 'delete' })
+    expect(resolveGraphKey(ev('y'), ctx())).toEqual({ action: 'copy' })
+    expect(resolveGraphKey(ev('m'), ctx())).toEqual({ action: 'menu' })
+    expect(resolveGraphKey(ev('a'), ctx())).toEqual({ action: 'actionsMenu' })
+    expect(resolveGraphKey(ev('/'), ctx())).toEqual({ action: 'help' })
+    expect(resolveGraphKey(ev('t'), ctx())).toEqual({ action: 'toggleTheme' })
+    expect(resolveGraphKey(ev('Enter'), ctx())).toEqual({ action: 'select' })
+    expect(resolveGraphKey(ev('f'), ctx())).toEqual({ action: 'showHints' })
+    expect(resolveGraphKey(ev('Escape'), ctx())).toEqual({ action: 'close' })
+    expect(resolveGraphKey(ev('H', { shift: true }), ctx())).toEqual({ action: 'history' })
+  })
+
+  it('resolves navigation actions to their direction', () => {
+    expect(resolveGraphKey(ev('j'), ctx())).toEqual({ action: 'nav', direction: 'j' })
+    expect(resolveGraphKey(ev('k'), ctx())).toEqual({ action: 'nav', direction: 'k' })
+    expect(resolveGraphKey(ev('h'), ctx())).toEqual({ action: 'nav', direction: 'h' })
+    expect(resolveGraphKey(ev('l'), ctx())).toEqual({ action: 'nav', direction: 'l' })
+  })
+
+  it('edit returns node data in node mode', () => {
+    const c = ctx({ edgeOrNode: 'nodes', focusedNodeId: 'n1' })
+    const hit = resolveGraphKey(ev('e'), c)
+    expect(hit.action).toBe('edit')
+    expect(hit.mode).toBe('Edit Node')
+    expect(hit.data.id).toBe('n1')
+    expect(c.modifier.getNodeData).toHaveBeenCalledWith('n1')
+  })
+
+  it('edit returns edge data in edge mode', () => {
+    const c = ctx({ edgeOrNode: 'edges', focusedEdgeId: 'e5', focusedNodeId: null })
+    const hit = resolveGraphKey(ev('e'), c)
+    expect(hit.action).toBe('edit')
+    expect(hit.mode).toBe('Edit Edge')
+    expect(hit.data.id).toBe('e5')
+    expect(c.modifier.getEdgeData).toHaveBeenCalledWith('e5')
+  })
+
+  it('edit resolves to null when nothing is focused', () => {
+    expect(resolveGraphKey(ev('e'), ctx({ focusedNodeId: null }))).toBeNull()
+  })
+
+  it('ignores keys that trigger no action', () => {
+    expect(resolveGraphKey(ev('q'), ctx())).toBeNull()
+    expect(resolveGraphKey(ev('Escape', { shift: true }), ctx())).toBeNull()
+  })
+
+  it('honors user rebinds', () => {
+    VueCookies.get.mockReturnValue({ shortcuts: { addNode: 'z' } })
+    expect(resolveGraphKey(ev('z'), ctx())).toEqual({ action: 'addNode' })
+    expect(resolveGraphKey(ev('n'), ctx())).toBeNull()
+  })
+
+  it('matches the default shortcut for each catalogued graph action', () => {
+    // Every graph action id in the catalog must map to at least one key.
+    const graph = Shortcuts.actions.filter((a) => a.group === 'graph')
+    for (const a of graph) {
+      const key = Shortcuts.combo(a.id)
+      const mods = {}
+      if (key.includes('shift')) mods.shift = true
+      const char = key.split('+').at(-1)
+      const keyName =
+        char === 'space' ? ' ' : char === 'escape' ? 'Escape' : char === 'enter' ? 'Enter' : char
+      const result = resolveGraphKey(ev(keyName, mods), ctx())
+      expect(result, `action ${a.id} should resolve`).not.toBeNull()
+    }
+  })
+})

--- a/src/helpers/OtherKeys.js
+++ b/src/helpers/OtherKeys.js
@@ -3,53 +3,23 @@ import VueCookies from 'vue-cookies'
 
 export default class OtherKeys {
   constructor(emitter, modifier, hintFunction) {
-    this.emitter       = emitter
-    this.modifier      = modifier
-    this.focusedIndex  = modifier.focusedIndex
+    this.emitter = emitter
+    this.modifier = modifier
+    this.focusedIndex = modifier.focusedIndex
     this.selectedNodes = modifier.selectedNodes
     this.doubleSelection = modifier.doubleSelection
     this.selectedEdges = modifier.selectedEdges || []
-    this.hintFunction  = hintFunction
+    this.hintFunction = hintFunction
   }
 
+  // Movement fallback for the graph view: navigation (j/k/h/l), hints (f)
+  // and selection (Enter). Emitter-based actions (menu, help, add, edit, ...)
+  // are resolved by GraphKeys + DiagramGraphView, not here.
   defaultActions(eventKey, edgeOrNode, focusedNodeId, focusedEdgeId) {
-    let d3Data = null
     this.focusedNodeId = focusedNodeId
     this.focusedEdgeId = focusedEdgeId
 
-    switch (eventKey) {
-      case 'm':
-        this.emitter.emit('changeActive', 'Menu')
-        break
-      case '/':
-        this.emitter.emit('showHelp')
-        break
-      case 'a':
-        this.emitter.emit('changeActive', 'Actions Menu')
-        break
-      case 't':
-        this.emitter.emit('toggleTheme')
-        break
-      case 'n':
-        this.modifier.addNode(D3Util.defaultNodeValues())
-        break
-      case 'd':
-        this.modifier.addEdge(D3Util.defaultEdgeValues())
-        break
-      case 'e':
-        if (edgeOrNode === 'edges') {
-          d3Data = this.modifier.getEdgeData(focusedEdgeId)
-          this.emitter.emit('changeActive', 'Edit Edge')
-        } else if (edgeOrNode === 'nodes') {
-          d3Data = this.modifier.getNodeData(focusedNodeId)
-          this.emitter.emit('changeActive', 'Edit Node')
-        }
-        break
-      default:
-        return this.Animate(eventKey, edgeOrNode)
-    }
-
-    return d3Data
+    return this.Animate(eventKey, edgeOrNode)
   }
 
   Animate(eventKey, nodeOrEdge) {
@@ -146,20 +116,20 @@ export default class OtherKeys {
   F(nodeOrEdge) {
     const renderer = this.modifier.renderer
     const elements = renderer
-      ? (nodeOrEdge === 'edges'
-          ? renderer.getAllEdgeElements()
-          : renderer.getAllNodeElements())
+      ? nodeOrEdge === 'edges'
+        ? renderer.getAllEdgeElements()
+        : renderer.getAllNodeElements()
       : []
 
-    const availHints    = this.buildHints(elements)
-    const hints         = {}
-    const settings      = VueCookies.get('settings') || {}
+    const availHints = this.buildHints(elements)
+    const hints = {}
+    const settings = VueCookies.get('settings') || {}
     const hintLinkColor = settings.hintLinkColor || '#ffffff'
-    const hintBGColor   = settings.hintBGColor   || '#36004c'
+    const hintBGColor = settings.hintBGColor || '#36004c'
 
     for (let i = 0; i < elements.length; i++) {
       const shortcut = availHints[i]
-      const el       = elements[i]
+      const el = elements[i]
 
       const badge = document.createElement('div')
       badge.className = 'hint-badge'
@@ -170,7 +140,7 @@ export default class OtherKeys {
         '<span class="hint-bracket htr"></span>',
         '<span class="hint-bracket hbl"></span>',
         '<span class="hint-bracket hbr"></span>',
-        `<a href="#" tabindex="-1"><span class="hint-char">${shortcut}</span></a>`,
+        `<a href="#" tabindex="-1"><span class="hint-char">${shortcut}</span></a>`
       ].join('')
       badge.addEventListener('click', this.hintFunction)
       el.appendChild(badge)

--- a/src/helpers/OtherKeys.test.js
+++ b/src/helpers/OtherKeys.test.js
@@ -44,44 +44,6 @@ function fakeElement() {
   }
 }
 
-describe('OtherKeys emitter routes', () => {
-  it('m / / / a / t emit their events', () => {
-    const { emitter, keys } = makeSut()
-    keys.defaultActions('m')
-    keys.defaultActions('/')
-    keys.defaultActions('a')
-    keys.defaultActions('t')
-    expect(emitter.emit).toHaveBeenNthCalledWith(1, 'changeActive', 'Menu')
-    expect(emitter.emit).toHaveBeenNthCalledWith(2, 'showHelp')
-    expect(emitter.emit).toHaveBeenNthCalledWith(3, 'changeActive', 'Actions Menu')
-    expect(emitter.emit).toHaveBeenNthCalledWith(4, 'toggleTheme')
-  })
-
-  it('n / d add a node / edge', () => {
-    const { modifier, keys } = makeSut()
-    keys.defaultActions('n')
-    keys.defaultActions('d')
-    expect(modifier.addNode).toHaveBeenCalledOnce()
-    expect(modifier.addEdge).toHaveBeenCalledOnce()
-  })
-
-  it('e edits the focused node and returns its data', () => {
-    const { emitter, modifier, keys } = makeSut()
-    const result = keys.defaultActions('e', 'nodes', 'n1', null)
-    expect(modifier.getNodeData).toHaveBeenCalledWith('n1')
-    expect(emitter.emit).toHaveBeenCalledWith('changeActive', 'Edit Node')
-    expect(result.id).toBe('n1')
-  })
-
-  it('e edits the focused edge', () => {
-    const { emitter, modifier, keys } = makeSut()
-    const result = keys.defaultActions('e', 'edges', null, 'e5')
-    expect(modifier.getEdgeData).toHaveBeenCalledWith('e5')
-    expect(emitter.emit).toHaveBeenCalledWith('changeActive', 'Edit Edge')
-    expect(result.id).toBe('e5')
-  })
-})
-
 describe('OtherKeys j/k navigation', () => {
   it('j moves to the next node, wrapping around', () => {
     const { keys } = makeSut()

--- a/src/helpers/Shortcuts.js
+++ b/src/helpers/Shortcuts.js
@@ -1,0 +1,233 @@
+import VueCookies from 'vue-cookies'
+
+// Central registry for user-rebindable shortcuts.
+//
+// Combo format: lowercase modifier tokens joined by '+' followed by a key
+// token, e.g. "meta+shift+s", "alt+l", "j", "escape", "shift+h".
+//
+// Defaults can differ per platform; user overrides (settings.shortcuts[id])
+// apply to every platform. Overrides are read from the settings cookie on
+// every call so rebinds take effect immediately without a reload.
+
+export const SHORTCUT_GROUPS = [
+  { id: 'forms', label: 'Forms & Dialogs' },
+  { id: 'graph', label: 'Graph' }
+]
+
+export const DEFAULT_SHORTCUTS = [
+  // ─── Forms & Dialogs ────────────────────────────────────────────────────
+  {
+    id: 'save',
+    group: 'forms',
+    label: 'Save (node / edge / diagram)',
+    mac: 'meta+shift+s',
+    other: 'alt+shift+s'
+  },
+  { id: 'close', group: 'forms', label: 'Close / cancel', mac: 'escape', other: 'escape' },
+  { id: 'login', group: 'forms', label: 'Login', mac: 'meta+l', other: 'alt+l' },
+  {
+    id: 'clear',
+    group: 'forms',
+    label: 'Clear label field',
+    mac: 'meta+shift+w',
+    other: 'alt+shift+w'
+  },
+  // ─── Graph ───────────────────────────────────────────────────────────────
+  { id: 'addNode', group: 'graph', label: 'Add node', mac: 'n', other: 'n' },
+  { id: 'addEdge', group: 'graph', label: 'Add edge', mac: 'd', other: 'd' },
+  { id: 'editElement', group: 'graph', label: 'Edit node / edge', mac: 'e', other: 'e' },
+  { id: 'deleteElement', group: 'graph', label: 'Delete node / edge', mac: 'x', other: 'x' },
+  { id: 'navDown', group: 'graph', label: 'Focus next element', mac: 'j', other: 'j' },
+  { id: 'navUp', group: 'graph', label: 'Focus previous element', mac: 'k', other: 'k' },
+  { id: 'navLeft', group: 'graph', label: 'Focus left', mac: 'h', other: 'h' },
+  { id: 'navRight', group: 'graph', label: 'Focus right', mac: 'l', other: 'l' },
+  { id: 'select', group: 'graph', label: 'Select / deselect', mac: 'enter', other: 'enter' },
+  { id: 'showHints', group: 'graph', label: 'Show element hints', mac: 'f', other: 'f' },
+  { id: 'toggleTheme', group: 'graph', label: 'Toggle theme', mac: 't', other: 't' },
+  { id: 'menu', group: 'graph', label: 'Open main menu', mac: 'm', other: 'm' },
+  { id: 'actionsMenu', group: 'graph', label: 'Open actions menu', mac: 'a', other: 'a' },
+  { id: 'help', group: 'graph', label: 'Show help', mac: '/', other: '/' },
+  { id: 'copyNode', group: 'graph', label: 'Copy focused node', mac: 'y', other: 'y' },
+  { id: 'history', group: 'graph', label: 'History panel', mac: 'shift+h', other: 'shift+h' }
+]
+
+// Combos owned by non-rebindable handlers (menu, palette, pan/zoom/layouts)
+// so the recorder can warn when a user assigns one of them to an action.
+const RESERVED_COMBOS = [
+  'meta+k',
+  'ctrl+k',
+  'alt+n',
+  'alt+o',
+  'alt+e',
+  'alt+s',
+  'alt+j',
+  'alt+k',
+  'alt+h',
+  'alt+l',
+  'alt+-',
+  'alt+=',
+  'alt+1',
+  'alt+2',
+  'alt+3',
+  'alt+4',
+  'alt+5',
+  'alt+6',
+  'alt+7',
+  'alt+8'
+]
+
+const MODIFIERS = ['meta', 'ctrl', 'alt', 'shift']
+const BARE_KEYS = [
+  'meta',
+  'control',
+  'alt',
+  'shift',
+  'capslock',
+  'numlock',
+  'scrolllock',
+  'unidentified'
+]
+
+const _actions = DEFAULT_SHORTCUTS
+const _byId = new Map(_actions.map((a) => [a.id, a]))
+
+export default {
+  isMac() {
+    if (typeof navigator === 'undefined') return false
+    const platform = navigator.platform || navigator.userAgentData?.platform || ''
+    return platform.toLowerCase().includes('mac') || /Mac|iPhone|iPad/.test(navigator.userAgent)
+  },
+
+  get actions() {
+    return _actions
+  },
+
+  action(id) {
+    return _byId.get(id)
+  },
+
+  overrides() {
+    const settings = VueCookies.get('settings')
+    return (settings && settings.shortcuts) || {}
+  },
+
+  // Effective combo for an action: user override wins over the platform default.
+  combo(id) {
+    const entry = _byId.get(id)
+    if (!entry) return null
+    const override = this.overrides()[id]
+    return override || (this.isMac() ? entry.mac : entry.other)
+  },
+
+  // Human-readable label for an action's effective combo.
+  label(id) {
+    return this.format(this.combo(id))
+  },
+
+  // Human-readable label for an arbitrary combo string.
+  format(combo) {
+    const p = parseCombo(combo)
+    if (!p.key) return String(combo || '')
+    const glyphs = {
+      meta: this.isMac() ? '⌘' : 'Ctrl',
+      ctrl: 'Ctrl',
+      alt: this.isMac() ? '⌥' : 'Alt',
+      shift: 'Shift'
+    }
+    const parts = ['meta', 'ctrl', 'alt', 'shift'].filter((m) => p[m]).map((m) => glyphs[m])
+    parts.push(displayKey(p.key))
+    return parts.join('+')
+  },
+
+  // Does this event trigger the given action (id or combo)?
+  matches(event, idOrCombo) {
+    const combo = _byId.has(idOrCombo) ? this.combo(idOrCombo) : idOrCombo
+    return matchesCombo(event, combo)
+  },
+
+  // Capture the keys a user pressed as a combo string. Returns null when the
+  // event cannot form a combo (bare modifier, unknown key).
+  comboFromEvent(event) {
+    const key = event && event.key
+    if (!key) return null
+    if (BARE_KEYS.includes(key.toLowerCase())) return null
+    const parts = []
+    if (event.metaKey) parts.push('meta')
+    if (event.ctrlKey) parts.push('ctrl')
+    if (event.altKey) parts.push('alt')
+    if (event.shiftKey) parts.push('shift')
+    parts.push(normalizeKey(key))
+    return parts.join('+')
+  },
+
+  // Non-blocking warnings for a recorded combo. ok=false only for combos that
+  // can never fire (no key). Everything else is allowed with warnings.
+  validate(combo) {
+    const p = parseCombo(combo)
+    if (!p.key)
+      return { ok: false, reasons: ['Combos need a key (modifiers alone are not enough)'] }
+    const reasons = []
+    if (['tab', 'arrowup', 'arrowdown', 'arrowleft', 'arrowright'].includes(p.key)) {
+      reasons.push('Used by menus and dropdowns — this may conflict')
+    }
+    if (p.meta && ['w', 't', 'r', 'q', 'l', '`'].includes(p.key)) {
+      reasons.push('Reserved by the browser on macOS (closes/reloads tabs)')
+    }
+    if (p.ctrl && ['w', 't', 'r', 'q', 'l'].includes(p.key)) {
+      reasons.push('Reserved by the browser (closes/reloads tabs)')
+    }
+    if (RESERVED_COMBOS.includes(combo)) {
+      reasons.push('Already used by another app feature (menu, palette, pan/zoom, layout)')
+    }
+    return { ok: true, reasons }
+  },
+
+  // Duplicate effective combos across actions, given a set of overrides.
+  conflicts(overrides = {}) {
+    const seen = {}
+    for (const a of _actions) {
+      const c = overrides[a.id] || (this.isMac() ? a.mac : a.other)
+      if (!c) continue
+      ;(seen[c] = seen[c] || []).push(a.id)
+    }
+    return Object.entries(seen)
+      .filter(([, ids]) => ids.length > 1)
+      .map(([combo, ids]) => ({ combo, ids }))
+  }
+}
+
+function normalizeKey(key) {
+  return key === ' ' ? 'space' : String(key).toLowerCase()
+}
+
+function displayKey(key) {
+  if (key === 'space') return 'Space'
+  if (key === 'escape') return 'Esc'
+  if (key === 'enter') return 'Enter'
+  if (key === 'tab') return 'Tab'
+  if (key.length === 1) return key.toUpperCase()
+  return key.charAt(0).toUpperCase() + key.slice(1)
+}
+
+export function parseCombo(combo) {
+  const parts = String(combo || '')
+    .toLowerCase()
+    .split('+')
+  const mods = { meta: false, ctrl: false, alt: false, shift: false }
+  const rest = []
+  for (const part of parts) {
+    if (MODIFIERS.includes(part)) mods[part] = true
+    else if (part) rest.push(part)
+  }
+  return { ...mods, key: rest[0] || null }
+}
+
+export function matchesCombo(event, combo) {
+  const p = parseCombo(combo)
+  if (!p.key) return false
+  if (Boolean(event.metaKey) !== p.meta) return false
+  if (Boolean(event.ctrlKey) !== p.ctrl) return false
+  if (Boolean(event.altKey) !== p.alt) return false
+  if (Boolean(event.shiftKey) !== p.shift) return false
+  return normalizeKey(event.key || '') === p.key
+}

--- a/src/helpers/Shortcuts.test.js
+++ b/src/helpers/Shortcuts.test.js
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import Shortcuts, { parseCombo, matchesCombo } from '@/helpers/Shortcuts.js'
+import VueCookies from 'vue-cookies'
+
+vi.mock('vue-cookies', () => ({
+  default: { get: vi.fn(), set: vi.fn() }
+}))
+
+function setOverrides(shortcuts) {
+  VueCookies.get.mockReturnValue(shortcuts ? { shortcuts } : null)
+}
+
+function ev(key, mods = {}) {
+  return {
+    key,
+    metaKey: !!mods.meta,
+    ctrlKey: !!mods.ctrl,
+    altKey: !!mods.alt,
+    shiftKey: !!mods.shift
+  }
+}
+
+describe('parseCombo', () => {
+  it('parses modifiers and key', () => {
+    expect(parseCombo('meta+shift+s')).toEqual({
+      meta: true,
+      ctrl: false,
+      alt: false,
+      shift: true,
+      key: 's'
+    })
+    expect(parseCombo('alt+l')).toEqual({
+      meta: false,
+      ctrl: false,
+      alt: true,
+      shift: false,
+      key: 'l'
+    })
+  })
+
+  it('treats single keys as bare', () => {
+    expect(parseCombo('j')).toEqual({
+      meta: false,
+      ctrl: false,
+      alt: false,
+      shift: false,
+      key: 'j'
+    })
+  })
+
+  it('returns null key for empty / modifier-only combos', () => {
+    expect(parseCombo('meta').key).toBeNull()
+    expect(parseCombo('').key).toBeNull()
+  })
+})
+
+describe('matchesCombo', () => {
+  it('matches letters regardless of shift-casing', () => {
+    expect(matchesCombo(ev('n'), 'n')).toBe(true)
+    expect(matchesCombo(ev('N', { shift: true }), 'shift+h')).toBe(false)
+    expect(matchesCombo(ev('H', { shift: true }), 'shift+h')).toBe(true)
+  })
+
+  it('requires exact modifier state', () => {
+    expect(matchesCombo(ev('s', { alt: true, shift: true }), 'alt+shift+s')).toBe(true)
+    expect(matchesCombo(ev('s', { meta: true, shift: true }), 'alt+shift+s')).toBe(false)
+    expect(matchesCombo(ev('s', { alt: true }), 'alt+shift+s')).toBe(false)
+  })
+
+  it('matches special keys', () => {
+    expect(matchesCombo(ev('Escape'), 'escape')).toBe(true)
+    expect(matchesCombo(ev('Enter'), 'enter')).toBe(true)
+    expect(matchesCombo(ev('/'), '/')).toBe(true)
+  })
+
+  it('matches space alias', () => {
+    expect(matchesCombo(ev(' '), 'space')).toBe(true)
+  })
+
+  it('returns false for unparseable combos', () => {
+    expect(matchesCombo(ev('a'), null)).toBe(false)
+    expect(matchesCombo(ev('a'), '')).toBe(false)
+  })
+})
+
+describe('platform defaults', () => {
+  beforeEach(() => {
+    setOverrides(null)
+    vi.spyOn(Shortcuts, 'isMac')
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('uses mac defaults on mac', () => {
+    Shortcuts.isMac.mockReturnValue(true)
+    expect(Shortcuts.combo('save')).toBe('meta+shift+s')
+    expect(Shortcuts.combo('close')).toBe('escape')
+    expect(Shortcuts.combo('login')).toBe('meta+l')
+    expect(Shortcuts.combo('history')).toBe('shift+h')
+  })
+
+  it('uses other-platform defaults elsewhere', () => {
+    Shortcuts.isMac.mockReturnValue(false)
+    expect(Shortcuts.combo('save')).toBe('alt+shift+s')
+    expect(Shortcuts.combo('login')).toBe('alt+l')
+  })
+})
+
+describe('overrides from settings cookie', () => {
+  beforeEach(() => {
+    vi.spyOn(Shortcuts, 'isMac').mockReturnValue(false)
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('user overrides win over defaults', () => {
+    setOverrides({ save: 'ctrl+shift+s', addNode: 'z' })
+    expect(Shortcuts.combo('save')).toBe('ctrl+shift+s')
+    expect(Shortcuts.combo('addNode')).toBe('z')
+    expect(Shortcuts.combo('addEdge')).toBe('d')
+  })
+
+  it('matches against the override', () => {
+    setOverrides({ addNode: 'z' })
+    expect(Shortcuts.matches(ev('z'), 'addNode')).toBe(true)
+    expect(Shortcuts.matches(ev('n'), 'addNode')).toBe(false)
+  })
+})
+
+describe('labels', () => {
+  beforeEach(() => {
+    setOverrides(null)
+    vi.spyOn(Shortcuts, 'isMac')
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('renders mac glyphs on mac', () => {
+    Shortcuts.isMac.mockReturnValue(true)
+    expect(Shortcuts.label('save')).toBe('⌘+Shift+S')
+    expect(Shortcuts.label('close')).toBe('Esc')
+    expect(Shortcuts.label('login')).toBe('⌘+L')
+    expect(Shortcuts.label('clear')).toBe('⌘+Shift+W')
+    expect(Shortcuts.label('history')).toBe('Shift+H')
+  })
+
+  it('renders alt/ctrl labels elsewhere', () => {
+    Shortcuts.isMac.mockReturnValue(false)
+    expect(Shortcuts.label('save')).toBe('Alt+Shift+S')
+    expect(Shortcuts.label('login')).toBe('Alt+L')
+    expect(Shortcuts.label('close')).toBe('Esc')
+    expect(Shortcuts.format('ctrl+shift+s')).toBe('Ctrl+Shift+S')
+  })
+
+  it('formats arbitrary combos', () => {
+    Shortcuts.isMac.mockReturnValue(true)
+    expect(Shortcuts.format('space')).toBe('Space')
+    expect(Shortcuts.format('enter')).toBe('Enter')
+    expect(Shortcuts.format('meta+alt+x')).toBe('⌘+⌥+X')
+  })
+})
+
+describe('comboFromEvent', () => {
+  it('records chords and bare keys', () => {
+    expect(Shortcuts.comboFromEvent(ev('S', { meta: true, shift: true }))).toBe('meta+shift+s')
+    expect(Shortcuts.comboFromEvent(ev('s', { alt: true }))).toBe('alt+s')
+    expect(Shortcuts.comboFromEvent(ev('j'))).toBe('j')
+    expect(Shortcuts.comboFromEvent(ev('Escape'))).toBe('escape')
+    expect(Shortcuts.comboFromEvent(ev(' '))).toBe('space')
+  })
+
+  it('rejects bare modifiers', () => {
+    expect(Shortcuts.comboFromEvent(ev('Meta', { meta: true }))).toBeNull()
+    expect(Shortcuts.comboFromEvent(ev('Shift', { shift: true }))).toBeNull()
+    expect(Shortcuts.comboFromEvent(ev(null))).toBeNull()
+  })
+})
+
+describe('validate', () => {
+  it('flags combos without a key', () => {
+    expect(Shortcuts.validate('meta').ok).toBe(false)
+    expect(Shortcuts.validate('').ok).toBe(false)
+  })
+
+  it('allows ordinary combos without warnings', () => {
+    expect(Shortcuts.validate('alt+shift+s')).toEqual({ ok: true, reasons: [] })
+    expect(Shortcuts.validate('j')).toEqual({ ok: true, reasons: [] })
+  })
+
+  it('warns on reserved app and browser combos', () => {
+    expect(Shortcuts.validate('meta+k').reasons.length).toBeGreaterThan(0)
+    expect(Shortcuts.validate('alt+n').reasons.length).toBeGreaterThan(0)
+    expect(Shortcuts.validate('meta+w').reasons.length).toBeGreaterThan(0)
+    expect(Shortcuts.validate('ctrl+w').reasons.length).toBeGreaterThan(0)
+  })
+
+  it('warns on navigation keys', () => {
+    expect(Shortcuts.validate('tab').reasons.length).toBeGreaterThan(0)
+    expect(Shortcuts.validate('arrowdown').reasons.length).toBeGreaterThan(0)
+  })
+})
+
+describe('conflicts', () => {
+  beforeEach(() => {
+    vi.spyOn(Shortcuts, 'isMac').mockReturnValue(false)
+  })
+  afterEach(() => vi.restoreAllMocks())
+
+  it('finds duplicate combos across actions', () => {
+    const result = Shortcuts.conflicts({ addNode: 'x', deleteElement: 'x' })
+    expect(result).toHaveLength(1)
+    expect(result[0].ids.sort()).toEqual(['addNode', 'deleteElement'])
+  })
+
+  it('returns empty when nothing collides', () => {
+    expect(Shortcuts.conflicts({ addNode: 'z' })).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
Adds user-configurable shortcuts for forms/dialogs and common graph actions, managed from a new Shortcuts section in Settings and persisted in the existing settings cookie.

## What's included
- **Shortcuts registry** (`src/helpers/Shortcuts.js`): platform-aware defaults, live cookie overrides, combo parsing/matching/validation, reserved-combo warnings. 23 unit tests.
- **ShortcutRecorder** (`src/components/ShortcutRecorder.vue`): press-to-record control with validation and conflict warnings.
- **Settings > Shortcuts**: Forms & Dialogs + Graph groups with per-action recorders and "Reset all shortcuts to defaults".
- **GraphKeys resolver** (`src/helpers/GraphKeys.js`): resolves graph-view keydowns to actions; `DiagramGraphView` dispatches on descriptors, falling back to AltKeys for pan/zoom/layouts. 8 unit tests.
- **Forms** (node/edge/diagram/login) route save/close/clear/login through the registry instead of static `@keyup` modifiers; Esc is the rebindable close.
- **Live labels**: `D3Util.shortcutLabels` delegates to the registry; the Helper pane shows current bindings.

Also earlier in this branch: save moved to `⌘+Shift+S`/`Alt+Shift+S` (plain `⌘+S` is intercepted by the browser) and form close moved to `Esc` (was `Ctrl/Cmd+C`, which collides with copy).

## Notes
- Conflicts and reserved combos (⌘K palette, Alt pan/zoom/layouts, Alt menu) are allowed with an inline warning, never blocked.
- 195 tests pass; eslint clean; production build succeeds.
