### PR TITLE
feat(collab): production collaboration features (history, shares, presence)

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+# Set to 'true' in .env.local to enable real-time collaboration features.
+VITE_COLLAB_ENABLED=false

--- a/src/App.vue
+++ b/src/App.vue
@@ -13,7 +13,10 @@ import DiagramForm from '@/components/DiagramForm.vue'
 import DiagramList from '@/components/DiagramList.vue'
 import Login from '@/components/Login.vue'
 import { computed, markRaw } from 'vue'
+import { useRoute } from 'vue-router'
 import D3DApi from '@/services/api'
+
+const route = useRoute()
 
 /*
 // Theme specific
@@ -32,7 +35,8 @@ function toggleTheme() {
     <!--
     TODO: move this to use a sheet, in order to allow to close the alert.  Currently the diagram is preventing closing the alert
     -->
-    <v-main app>
+    <RouterView v-if="route.name === 'join'" />
+    <v-main app v-else>
       <Teleport to="body">
         <div class="fx-toast-stack">
           <TransitionGroup name="fx-toast">
@@ -309,6 +313,15 @@ export default {
       } else {
         this.loadDiagram(id)
       }
+    })
+
+    this.emitter.on('diagram:reload', (id) => {
+      if (id) this.loadFromServer(id)
+    })
+
+    this.emitter.on('diagram:updated-remote', () => {
+      const id = this.d3dInfo?.id
+      if (id) this.loadFromServer(id)
     })
 
     this.emitter.on('toggleTheme', () => {

--- a/src/components/DiagramGraphView.vue
+++ b/src/components/DiagramGraphView.vue
@@ -1,7 +1,5 @@
 <template>
-  <div
-    @keydown.prevent="keyPress($event)"
-  >
+  <div @keydown.prevent="keyPress($event)">
     <FocusTrap
       v-model:active="trapGraph"
       :escapeDeactivates="false"
@@ -12,14 +10,14 @@
       <div id="trap" ref="trapDiv" class="trap is-active">
         <div v-if="diagramInfo" class="d3d-info">
           <h1>D3DInfo:</h1>
-          SelectedNodes: {{ selectedNodes }} <br>
-          SelectedEdges: {{ selectedEdges }} <br>
-          DoubleSelection: {{ doubleSelection }} <br>
-          FocusedEdgeID: {{ focusedEdgeId }} <br>
-          FocusedNodeID: {{ focusedNodeId }} <br>
-          Hints: {{ hints }} <br>
-          FocusedIndex: {{ focusedIndex }} <br>
-          EdgesOrNodes: {{ edgeOrNode }} <br>
+          SelectedNodes: {{ selectedNodes }} <br />
+          SelectedEdges: {{ selectedEdges }} <br />
+          DoubleSelection: {{ doubleSelection }} <br />
+          FocusedEdgeID: {{ focusedEdgeId }} <br />
+          FocusedNodeID: {{ focusedNodeId }} <br />
+          Hints: {{ hints }} <br />
+          FocusedIndex: {{ focusedIndex }} <br />
+          EdgesOrNodes: {{ edgeOrNode }} <br />
         </div>
 
         <!-- Three.js mounts its CSS3D + WebGL canvases here -->
@@ -27,7 +25,7 @@
           ref="threeContainer"
           tabindex="0"
           class="three-container"
-          @mousedown="$event.currentTarget.focus(); $event.preventDefault()"
+          @mousedown="_onContainerMousedown"
           @focusout="onContainerFocusOut"
         />
 
@@ -48,9 +46,21 @@
           </span>
         </div>
 
+        <div v-if="hasPeers" class="collab-peers-hud">
+          <span
+            v-for="(peer, cid) in peers"
+            :key="cid"
+            class="peer-avatar"
+            :style="{ background: peer.color }"
+            :title="peer.displayName"
+            >{{ initials(peer.displayName) }}</span
+          >
+        </div>
+
+        <div v-if="isViewOnly" class="view-only-badge">VIEW ONLY</div>
+
         <div v-if="graphEmpty" class="graph-empty-hint">
-          Empty diagram —
-          press <span class="kbd">n</span> to create a node
+          Empty diagram — press <span class="kbd">n</span> to create a node
           <span class="sep">·</span>
           <span class="kbd">/</span> for help
         </div>
@@ -76,6 +86,29 @@
           />
         </div>
       </transition>
+      <transition name="fx-scrim">
+        <div v-if="showHistory" class="fx-scrim" @click="showHistory = false"></div>
+      </transition>
+      <transition name="fx-panel">
+        <div v-if="showHistory" class="fx-hud-stage">
+          <HistoryPanel
+            :dagId="(modifier?.value ?? modifier)?.d3dInfo?.id"
+            @close="showHistory = false"
+            @restored="onHistoryRestored"
+          />
+        </div>
+      </transition>
+      <transition name="fx-scrim">
+        <div v-if="showShare" class="fx-scrim" @click="showShare = false"></div>
+      </transition>
+      <transition name="fx-panel">
+        <div v-if="showShare" class="fx-hud-stage">
+          <ShareDialog
+            :dagId="(modifier?.value ?? modifier)?.d3dInfo?.id"
+            @close="showShare = false"
+          />
+        </div>
+      </transition>
     </Teleport>
   </div>
 </template>
@@ -86,38 +119,66 @@ import CytoscapeRenderer from '@/helpers/CytoscapeRenderer'
 import { markRaw } from 'vue'
 import D3EdgeForm from '@/components/D3EdgeForm.vue'
 import D3NodeForm from '@/components/D3NodeForm.vue'
+import HistoryPanel from '@/components/HistoryPanel.vue'
+import ShareDialog from '@/components/ShareDialog.vue'
 import Hints from '@/helpers/Hints.js'
 import AltKeys from '@/helpers/AltKeys.js'
 import OtherKeys from '@/helpers/OtherKeys.js'
+import * as collab from '@/services/collab'
 import { resolveGraphKey } from '@/helpers/GraphKeys.js'
+
+function _decodeJwt(token) {
+  try {
+    return JSON.parse(atob(token.split('.')[1]))
+  } catch {
+    return {}
+  }
+}
+
+function _isViewOnly() {
+  const claims = _decodeJwt(localStorage.getItem('token') || '')
+  return claims.iss === 'd3d-share' && claims.role !== 'edit'
+}
+
+const _PEER_COLORS = ['#ef5350', '#ab47bc', '#29b6f6', '#26a69a', '#ffb300', '#66bb6a']
+function _sessionColor() {
+  const id = sessionStorage.getItem('d3d_collab_client_id') || ''
+  let h = 0
+  for (const c of id) h = (h * 31 + c.charCodeAt(0)) & 0xffffffff
+  return _PEER_COLORS[Math.abs(h) % _PEER_COLORS.length]
+}
 
 export default {
   name: 'DiagramGraphView',
   props: ['active'],
   inject: ['modifier'],
-  components: { D3NodeForm, D3EdgeForm },
+  components: { D3NodeForm, D3EdgeForm, HistoryPanel, ShareDialog },
   data() {
     return {
-      edgeOrNode:      'nodes',
-      focusedIndex:    null,
-      trapGraph:       true,
-      focusedEdgeId:   null,
-      focusedNodeId:   null,
+      edgeOrNode: 'nodes',
+      focusedIndex: null,
+      trapGraph: true,
+      focusedEdgeId: null,
+      focusedNodeId: null,
       hintKeysReplaced: '',
-      hints:           {},
-      d3Data:          {},
-      diagramInfo:     false,
-      selectedNodes:   [],
-      selectedEdges:   [],
+      hints: {},
+      d3Data: {},
+      diagramInfo: false,
+      selectedNodes: [],
+      selectedEdges: [],
       doubleSelection: [],
-      openSheet:       false,
-      paletteOpen:     false,
-      escCount:        0,
-      threeDRenderer:  null,
-      graphEmpty:      false,
-      zoomLevel:       1,
-      nodeCount:       0,
-      edgeCount:       0,
+      openSheet: false,
+      paletteOpen: false,
+      escCount: 0,
+      threeDRenderer: null,
+      graphEmpty: false,
+      zoomLevel: 1,
+      nodeCount: 0,
+      edgeCount: 0,
+      peers: {},
+      collabStatus: 'disconnected',
+      showHistory: false,
+      showShare: false
     }
   },
   mounted() {
@@ -135,10 +196,12 @@ export default {
     this.emitter.on('d3ResetValues', () => this.resetValues())
     this.emitter.on('scene-updated', ({ count, nodes, edges }) => {
       this.graphEmpty = count === 0
-      this.nodeCount  = nodes || 0
-      this.edgeCount  = edges || 0
+      this.nodeCount = nodes || 0
+      this.edgeCount = edges || 0
     })
-    this.emitter.on('viewport-changed', ({ zoom }) => { this.zoomLevel = zoom })
+    this.emitter.on('viewport-changed', ({ zoom }) => {
+      this.zoomLevel = zoom
+    })
 
     this.emitter.on('setSheetToFalse', () => {
       this.openSheet = false
@@ -148,7 +211,7 @@ export default {
     })
 
     this.emitter.on('edgeOrNode', (selection) => {
-      if (selection === 'Select Edges')     this.edgeOrNode = 'edges'
+      if (selection === 'Select Edges') this.edgeOrNode = 'edges'
       else if (selection === 'Select Node') this.edgeOrNode = 'nodes'
     })
 
@@ -164,9 +227,23 @@ export default {
       this.paletteOpen = false
       if (this.active === 'Graph') this.trapGraph = true
     })
+
+    if (import.meta.env.VITE_COLLAB_ENABLED === 'true') {
+      collab.onStatusChange((s) => {
+        this.collabStatus = s
+      })
+      collab.onPresence((msg) => {
+        this.peers = { ...this.peers, [msg.clientId]: msg }
+        this.threeDRenderer?.setPeerSelections(this.peers)
+      })
+      collab.onDiagramUpdated((msg) => {
+        this.emitter.emit('diagram:updated-remote', msg)
+      })
+    }
   },
   beforeUnmount() {
     if (this.threeDRenderer) this.threeDRenderer.teardown()
+    if (import.meta.env.VITE_COLLAB_ENABLED === 'true') collab.disconnect()
   },
   methods: {
     _initRenderer() {
@@ -203,7 +280,8 @@ export default {
         this.openSheet ||
         this.paletteOpen ||
         document.activeElement !== document.body
-      ) return
+      )
+        return
       const el = this.$refs.threeContainer
       if (!el) return
       setTimeout(() => {
@@ -213,7 +291,8 @@ export default {
           this.paletteOpen ||
           document.activeElement !== document.body ||
           document.activeElement === el
-        ) return
+        )
+          return
         el.focus({ preventScroll: true })
       }, 0)
     },
@@ -245,6 +324,7 @@ export default {
     // populate from the currently focused element and only open the form when
     // there is something to edit.
     _openEdit(which) {
+      if (_isViewOnly()) return
       const mod = this.modifier?.value ?? this.modifier
       if (!mod) return
       const isNode = which === 'nodes'
@@ -253,7 +333,7 @@ export default {
       if (!data?.id) {
         this.emitter.emit('appMessage', {
           message: `Focus a ${isNode ? 'node' : 'edge'} first (j/k to navigate) to edit it`,
-          status: 'info',
+          status: 'info'
         })
         return
       }
@@ -263,6 +343,7 @@ export default {
     },
 
     hintSelection(data) {
+      if (_isViewOnly()) return
       if (D3Util.debug) console.log('hintSelection', data)
       const mod = this.modifier?.value ?? this.modifier
       if (!mod) return
@@ -271,7 +352,7 @@ export default {
       if (data.dataset?.type === 'edge') {
         const edgeId = data.dataset.edgeId
         if (!edgeId) return
-        this.d3Data        = mod.getEdgeData(edgeId)
+        this.d3Data = mod.getEdgeData(edgeId)
         this.focusedEdgeId = edgeId
         this.emitter.emit('changeActive', 'Edit Edge')
         this.openSheet = true
@@ -286,7 +367,7 @@ export default {
         this.d3Data = mod.getEdgeData(data.id)
         this.emitter.emit('changeActive', 'Edit Edge')
       } else {
-        this.d3Data        = mod.getNodeData(nodeId)
+        this.d3Data = mod.getNodeData(nodeId)
         this.focusedNodeId = nodeId
         this.threeDRenderer?.setFocusedNode(nodeId)
         this.emitter.emit('changeActive', 'Edit Node')
@@ -299,38 +380,64 @@ export default {
       const tag = event.target?.tagName
       if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
 
+      // View-only share links: block all mutating operations
+      if (_isViewOnly()) {
+        const mutatingKeys = ['e', 'x', 'S', 'a', 'n']
+        if (event.altKey || event.metaKey || mutatingKeys.includes(event.key)) return
+      }
+
       // Ignore modifier-only, navigation and function keys (not shortcuts)
-      const ignored = ['Alt', 'Control', 'Meta', 'Shift', 'CapsLock', 'Tab',
-        'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Backspace',
-        'Delete', 'Home', 'End', 'PageUp', 'PageDown', 'ContextMenu',
-        'NumLock', 'ScrollLock', 'PrintScreen', 'Pause', 'Unidentified']
+      const ignored = [
+        'Alt',
+        'Control',
+        'Meta',
+        'Shift',
+        'CapsLock',
+        'Tab',
+        'ArrowUp',
+        'ArrowDown',
+        'ArrowLeft',
+        'ArrowRight',
+        'Backspace',
+        'Delete',
+        'Home',
+        'End',
+        'PageUp',
+        'PageDown',
+        'ContextMenu',
+        'NumLock',
+        'ScrollLock',
+        'PrintScreen',
+        'Pause',
+        'Unidentified'
+      ]
       if (ignored.includes(event.key) || event.key.startsWith('F')) return
 
       const mod = this.modifier?.value ?? this.modifier
       if (!mod || typeof mod.redraw !== 'function') return
 
-      mod.focusedIndex   = this.focusedIndex
-      mod.selectedNodes  = this.selectedNodes
+      mod.focusedIndex = this.focusedIndex
+      mod.selectedNodes = this.selectedNodes
       mod.doubleSelection = this.doubleSelection
-      mod.selectedEdges  = this.selectedEdges
+      mod.selectedEdges = this.selectedEdges
 
       if (D3Util.debug) console.log('keyPress', event)
 
       if (Object.keys(this.hints).length >= 1) {
         const hints = new Hints()
-        hints.data             = this.hints
+        hints.data = this.hints
         hints.hintKeysReplaced = this.hintKeysReplaced
         const data = hints.followLinks(event)
 
         if (Object.keys(data.hints).length > 1) {
-          this.hints           = data.hints
+          this.hints = data.hints
           this.hintKeysReplaced = data.hintKeys
         } else {
           if (event.key !== 'Escape') {
             const target = data.hints[data.hintKeys]
             if (target) this.hintSelection(target)
           }
-          this.hints           = {}
+          this.hints = {}
           this.hintKeysReplaced = ''
           hints.removeHints(data.hints)
         }
@@ -377,6 +484,9 @@ export default {
             this.d3Data = graph.data
             this.emitter.emit('changeActive', graph.mode)
             this.openSheet = true
+            break
+          case 'share':
+            if (mod?.d3dInfo?.id) this.showShare = true
             break
           case 'delete':
             if (this.edgeOrNode === 'nodes') {
@@ -438,16 +548,37 @@ export default {
       }
     },
 
+    _onContainerMousedown(event) {
+      event.currentTarget.focus()
+      event.preventDefault()
+    },
+
+    initials(name) {
+      return (name || '?')
+        .split(/\s+/)
+        .map((w) => w[0])
+        .join('')
+        .slice(0, 2)
+        .toUpperCase()
+    },
+
+    onHistoryRestored() {
+      this.showHistory = false
+      const mod = this.modifier?.value ?? this.modifier
+      const id = mod?.d3dInfo?.id
+      if (id) this.emitter.emit('diagram:reload', id)
+    },
+
     _clearMultiSelection() {
-      this.selectedNodes   = []
-      this.selectedEdges   = []
+      this.selectedNodes = []
+      this.selectedEdges = []
       this.doubleSelection = []
       this.threeDRenderer?.clearSelectionCrosshairs()
       const mod = this.modifier?.value ?? this.modifier
       if (mod) {
-        mod.selectedNodes    = []
-        mod.doubleSelection  = []
-        mod.selectedEdges    = []
+        mod.selectedNodes = []
+        mod.doubleSelection = []
+        mod.selectedEdges = []
       }
     },
 
@@ -462,13 +593,13 @@ export default {
         if (this.focusedEdgeId) mod.removeEdgeSelectionById(this.focusedEdgeId)
       }
       this.threeDRenderer?.clearSelectionCrosshairs()
-      this.selectedNodes   = []
-      this.selectedEdges   = []
+      this.selectedNodes = []
+      this.selectedEdges = []
       this.doubleSelection = []
-      this.focusedIndex    = null
-      this.focusedEdgeId   = null
-      this.focusedNodeId   = null
-      this.escCount        = 0
+      this.focusedIndex = null
+      this.focusedEdgeId = null
+      this.focusedNodeId = null
+      this.escCount = 0
       if (mod) mod.redraw()
       this.emitter.emit('changeActive')
     },
@@ -478,15 +609,21 @@ export default {
     _syncSelectionCrosshairs() {
       const mod = this.modifier?.value ?? this.modifier
       if (!mod || !this.threeDRenderer) return
-      const ids  = (this.selectedNodes || []).map(i => mod.getNodeId(i)).filter(Boolean)
-      const dIds = (this.doubleSelection || []).map(i => mod.getNodeId(i)).filter(Boolean)
+      const ids = (this.selectedNodes || []).map((i) => mod.getNodeId(i)).filter(Boolean)
+      const dIds = (this.doubleSelection || []).map((i) => mod.getNodeId(i)).filter(Boolean)
       this.threeDRenderer.setSelectedNodes(ids, dIds)
-    },
+    }
   },
   computed: {
     zoomDisplay() {
       return (this.zoomLevel || 1).toFixed(2) + '×'
     },
+    hasPeers() {
+      return Object.keys(this.peers).length > 0
+    },
+    isViewOnly() {
+      return _isViewOnly()
+    }
   },
   watch: {
     // When App.vue replaces the modifier (new diagram opened), reconnect renderer
@@ -497,30 +634,46 @@ export default {
           mod.renderer = this.threeDRenderer
           mod.redraw()
         }
+        if (import.meta.env.VITE_COLLAB_ENABLED === 'true') {
+          collab.disconnect()
+          this.peers = {}
+          const id = mod?.d3dInfo?.id
+          if (id) collab.connect(id)
+        }
       },
-      deep: false,
+      deep: false
+    },
+    focusedNodeId(id) {
+      if (import.meta.env.VITE_COLLAB_ENABLED !== 'true') return
+      const payload = _decodeJwt(localStorage.getItem('token') || '')
+      collab.sendPresence({
+        displayName:
+          localStorage.getItem('d3d_anon_name') || payload.username || payload.sub || 'Guest',
+        color: _sessionColor(),
+        selection: id ? [id] : []
+      })
     },
     active(val) {
       if (this.escCount === 3) {
-        this.selectedNodes   = []
-        this.selectedEdges   = []
-        this.focusedIndex    = null
-        this.focusedEdgeId   = null
-        this.focusedNodeId   = null
-        this.escCount        = 0
+        this.selectedNodes = []
+        this.selectedEdges = []
+        this.focusedIndex = null
+        this.focusedEdgeId = null
+        this.focusedNodeId = null
+        this.escCount = 0
       } else {
         this.escCount++
       }
       this.trapGraph = val === 'Graph'
 
-      const isEdit = val === 'Add Node' || val === 'Edit Node' ||
-                     val === 'Add Edge' || val === 'Edit Edge'
+      const isEdit =
+        val === 'Add Node' || val === 'Edit Node' || val === 'Add Edge' || val === 'Edit Edge'
       this.openSheet = isEdit
       if (isEdit) {
         this.$nextTick(() => this.threeDRenderer?.zoomTo(this.d3Data?.id))
       }
-    },
-  },
+    }
+  }
 }
 </script>
 
@@ -620,12 +773,58 @@ export default {
   top: 4px;
   left: 4px;
   z-index: 10;
-  background: rgba(0,0,0,0.5);
+  background: rgba(0, 0, 0, 0.5);
   color: #fff;
   padding: 4px 8px;
   font-size: 11px;
   pointer-events: none;
 }
 
-h1, h2 { font-weight: normal; }
+h1,
+h2 {
+  font-weight: normal;
+}
+
+.collab-peers-hud {
+  position: absolute;
+  top: 10px;
+  left: 12px;
+  z-index: 6;
+  display: flex;
+  gap: 6px;
+  pointer-events: none;
+}
+
+.peer-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  letter-spacing: 0.05em;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+  pointer-events: auto;
+  cursor: default;
+}
+
+.view-only-badge {
+  position: absolute;
+  top: 10px;
+  right: 12px;
+  z-index: 6;
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  letter-spacing: 0.08em;
+  pointer-events: none;
+}
 </style>

--- a/src/components/HistoryPanel.vue
+++ b/src/components/HistoryPanel.vue
@@ -1,0 +1,265 @@
+<template>
+  <div class="fx-panel" @keydown.esc="$emit('close')">
+    <focus-trap v-model:active="enableTrap" :escape-deactivates="false">
+      <div tabindex="0" class="fx-panel-inner">
+        <header class="fx-panel-header">
+          <div class="fx-panel-title">
+            <span class="fx-title-chip fx-chip-edit">HIST</span>
+            <h2 class="fx-title">HISTORY</h2>
+          </div>
+          <button type="button" class="fx-close" aria-label="Close" @click="$emit('close')">
+            ✕
+          </button>
+        </header>
+
+        <div class="fx-panel-body">
+          <div v-if="loading" class="hist-loading">Loading…</div>
+
+          <div v-else-if="entries.length === 0" class="hist-empty">No history yet.</div>
+
+          <ul v-else class="hist-list">
+            <li v-for="entry in entries" :key="entry.id" class="hist-entry">
+              <div class="hist-meta">
+                <span class="hist-time" :title="entry.savedAt">{{
+                  formatTime(entry.savedAt)
+                }}</span>
+                <span v-if="entry.savedBy" class="hist-user">{{ entry.savedBy }}</span>
+              </div>
+              <button
+                class="hist-restore-btn"
+                :disabled="restoring === entry.id"
+                @click="confirmRestore(entry)"
+              >
+                {{ restoring === entry.id ? 'Restoring…' : 'Restore' }}
+              </button>
+            </li>
+          </ul>
+        </div>
+
+        <div v-if="confirmEntry" class="hist-confirm-overlay">
+          <div class="hist-confirm-box">
+            <p class="hist-confirm-msg">
+              Restore snapshot from<br />
+              <strong>{{ formatTime(confirmEntry.savedAt) }}</strong
+              >?<br />
+              <span class="hist-confirm-warn">Current diagram will be overwritten.</span>
+            </p>
+            <div class="hist-confirm-actions">
+              <button class="hist-btn-cancel" @click="confirmEntry = null">Cancel</button>
+              <button class="hist-btn-confirm" @click="doRestore(confirmEntry)">Restore</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </focus-trap>
+  </div>
+</template>
+
+<script>
+import api from '@/services/api'
+
+export default {
+  name: 'HistoryPanel',
+  props: {
+    dagId: { type: String, required: true }
+  },
+  emits: ['close', 'restored'],
+  data() {
+    return {
+      enableTrap: true,
+      loading: true,
+      entries: [],
+      restoring: null,
+      confirmEntry: null,
+      errorMsg: null
+    }
+  },
+  async mounted() {
+    await this.fetchHistory()
+  },
+  methods: {
+    async fetchHistory() {
+      this.loading = true
+      try {
+        const data = await api.getHistory(this.dagId)
+        this.entries = data?.history ?? []
+      } catch {
+        this.entries = []
+      } finally {
+        this.loading = false
+      }
+    },
+
+    confirmRestore(entry) {
+      this.confirmEntry = entry
+    },
+
+    async doRestore(entry) {
+      this.confirmEntry = null
+      this.restoring = entry.id
+      try {
+        await api.restoreHistory(this.dagId, entry.id)
+        this.$emit('restored')
+      } catch {
+        // silent — parent will handle via reload
+      } finally {
+        this.restoring = null
+      }
+    },
+
+    formatTime(iso) {
+      if (!iso) return '—'
+      const d = new Date(iso)
+      return d.toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit'
+      })
+    }
+  }
+}
+</script>
+
+<style scoped>
+.fx-panel-body {
+  overflow-y: auto;
+  flex: 1;
+  padding: 12px 16px;
+}
+
+.hist-loading,
+.hist-empty {
+  color: rgb(var(--fx-ink-dim));
+  font-size: 13px;
+  padding: 16px 0;
+  text-align: center;
+}
+
+.hist-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.hist-entry {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: rgba(var(--fx-glass-bottom), 0.5);
+  border: 1px solid rgba(var(--fx-accent), 0.15);
+}
+
+.hist-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.hist-time {
+  font-size: 12px;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  color: rgb(var(--fx-ink));
+  white-space: nowrap;
+}
+
+.hist-user {
+  font-size: 10px;
+  color: rgb(var(--fx-ink-dim));
+  truncate: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.hist-restore-btn {
+  flex-shrink: 0;
+  padding: 3px 10px;
+  border-radius: 4px;
+  border: 1px solid rgba(var(--fx-accent), 0.5);
+  background: transparent;
+  color: rgb(var(--fx-ink));
+  font-size: 11px;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.hist-restore-btn:hover:not(:disabled) {
+  background: rgba(var(--fx-accent), 0.15);
+}
+
+.hist-restore-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* confirmation overlay */
+.hist-confirm-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  border-radius: inherit;
+}
+
+.hist-confirm-box {
+  background: rgb(var(--v-theme-surface));
+  border: 1px solid rgba(var(--fx-accent), 0.4);
+  border-radius: 10px;
+  padding: 20px 24px;
+  max-width: 280px;
+  text-align: center;
+}
+
+.hist-confirm-msg {
+  font-size: 13px;
+  color: rgb(var(--v-theme-on-surface));
+  margin-bottom: 16px;
+  line-height: 1.6;
+}
+
+.hist-confirm-warn {
+  font-size: 11px;
+  color: rgb(var(--fx-ink-dim));
+}
+
+.hist-confirm-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+}
+
+.hist-btn-cancel,
+.hist-btn-confirm {
+  padding: 5px 16px;
+  border-radius: 5px;
+  font-size: 12px;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  cursor: pointer;
+  border: 1px solid rgba(var(--fx-accent), 0.4);
+}
+
+.hist-btn-cancel {
+  background: transparent;
+  color: rgb(var(--fx-ink-dim));
+}
+
+.hist-btn-confirm {
+  background: rgba(var(--fx-accent), 0.2);
+  color: rgb(var(--fx-ink));
+}
+
+.hist-btn-confirm:hover {
+  background: rgba(var(--fx-accent), 0.35);
+}
+</style>

--- a/src/components/JoinView.vue
+++ b/src/components/JoinView.vue
@@ -1,0 +1,79 @@
+<template>
+  <div class="join-screen">
+    <div class="join-card">
+      <div v-if="error" class="join-error">
+        <p class="join-error-msg">{{ error }}</p>
+        <a href="/" class="join-home-link">Go to home</a>
+      </div>
+      <div v-else class="join-loading">Opening shared diagram…</div>
+    </div>
+  </div>
+</template>
+
+<script>
+import api from '@/services/api'
+
+export default {
+  name: 'JoinView',
+  data() {
+    return { error: null }
+  },
+  async mounted() {
+    const token = this.$route.params.token
+    if (!token) {
+      this.error = 'Invalid share link.'
+      return
+    }
+
+    const data = await api.exchangeShare(token)
+    if (!data || data.status !== 'ok') {
+      this.error = data && data.error ? data.error : 'Invalid, expired, or revoked share link.'
+      return
+    }
+
+    localStorage.setItem('token', token)
+    if (data.anonName) localStorage.setItem('d3d_anon_name', data.anonName)
+    this.$cookies.set('LastLocallySavedItemId', data.dagId)
+    window.location.href = '/'
+  }
+}
+</script>
+
+<style scoped>
+.join-screen {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(var(--v-theme-background, 255 255 255));
+}
+
+.join-card {
+  padding: 32px 40px;
+  border-radius: 12px;
+  background: rgba(var(--fx-glass-bottom, 255 255 255), 0.9);
+  border: 1px solid rgba(128, 128, 128, 0.2);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+  text-align: center;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+}
+
+.join-loading {
+  font-size: 14px;
+  color: #888;
+}
+
+.join-error-msg {
+  font-size: 14px;
+  color: #ef5350;
+  margin-bottom: 16px;
+}
+
+.join-home-link {
+  font-size: 12px;
+  color: inherit;
+  opacity: 0.6;
+  text-decoration: underline;
+}
+</style>

--- a/src/components/ShareDialog.vue
+++ b/src/components/ShareDialog.vue
@@ -1,0 +1,286 @@
+<template>
+  <div class="fx-panel" @keydown.esc="$emit('close')">
+    <focus-trap v-model:active="enableTrap" :escape-deactivates="false">
+      <div tabindex="0" class="fx-panel-inner">
+        <header class="fx-panel-header">
+          <div class="fx-panel-title">
+            <span class="fx-title-chip fx-chip-edit">SHR</span>
+            <h2 class="fx-title">SHARE</h2>
+          </div>
+          <button type="button" class="fx-close" aria-label="Close" @click="$emit('close')">
+            ✕
+          </button>
+        </header>
+
+        <div class="fx-panel-body">
+          <div class="share-form">
+            <div class="share-field">
+              <label class="share-label">ROLE</label>
+              <div class="share-seg">
+                <button
+                  class="share-seg-btn"
+                  :class="{ active: role === 'view' }"
+                  @click="role = 'view'"
+                >
+                  View
+                </button>
+                <button
+                  class="share-seg-btn"
+                  :class="{ active: role === 'edit' }"
+                  @click="role = 'edit'"
+                >
+                  Edit
+                </button>
+              </div>
+            </div>
+
+            <div class="share-field">
+              <label class="share-label">EXPIRES IN</label>
+              <div class="share-seg">
+                <button
+                  v-for="d in [1, 7, 30]"
+                  :key="d"
+                  class="share-seg-btn"
+                  :class="{ active: expDays === d }"
+                  @click="expDays = d"
+                >
+                  {{ d }}d
+                </button>
+              </div>
+            </div>
+
+            <button class="share-generate-btn" :disabled="generating" @click="generate">
+              {{ generating ? 'Generating…' : 'Generate Link' }}
+            </button>
+          </div>
+
+          <div v-if="generatedLink" class="share-result">
+            <div class="share-link-row">
+              <input
+                ref="linkInput"
+                class="share-link-input"
+                :value="generatedLink"
+                readonly
+                @click="selectAll"
+              />
+              <button class="share-copy-btn" :class="{ copied }" @click="copyLink">
+                {{ copied ? '✓' : 'Copy' }}
+              </button>
+            </div>
+            <p class="share-hint">
+              Anyone with this link can {{ role }} this diagram for {{ expDays }} day{{
+                expDays !== 1 ? 's' : ''
+              }}.
+            </p>
+          </div>
+
+          <div v-if="errorMsg" class="share-error">{{ errorMsg }}</div>
+        </div>
+      </div>
+    </focus-trap>
+  </div>
+</template>
+
+<script>
+import api from '@/services/api'
+
+export default {
+  name: 'ShareDialog',
+  props: {
+    dagId: { type: String, required: true }
+  },
+  emits: ['close'],
+  data() {
+    return {
+      enableTrap: true,
+      role: 'view',
+      expDays: 7,
+      generating: false,
+      generatedLink: null,
+      copied: false,
+      errorMsg: null
+    }
+  },
+  methods: {
+    async generate() {
+      this.generating = true
+      this.generatedLink = null
+      this.errorMsg = null
+      try {
+        const data = await api.createShare(this.dagId, { role: this.role, expDays: this.expDays })
+        if (data?.token) {
+          this.generatedLink = window.location.origin + '/join/' + data.token
+        } else {
+          this.errorMsg = data?.error || 'Failed to generate link'
+        }
+      } catch {
+        this.errorMsg = 'Failed to generate link'
+      } finally {
+        this.generating = false
+      }
+    },
+
+    async copyLink() {
+      if (!this.generatedLink) return
+      try {
+        await navigator.clipboard.writeText(this.generatedLink)
+        this.copied = true
+        setTimeout(() => {
+          this.copied = false
+        }, 2000)
+      } catch {
+        this.selectAll()
+      }
+    },
+
+    selectAll() {
+      this.$refs.linkInput?.select()
+    }
+  }
+}
+</script>
+
+<style scoped>
+.fx-panel-body {
+  overflow-y: auto;
+  flex: 1;
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.share-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.share-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.share-label {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: rgb(var(--fx-ink-dim));
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+}
+
+.share-seg {
+  display: flex;
+  gap: 4px;
+}
+
+.share-seg-btn {
+  flex: 1;
+  padding: 5px 10px;
+  border-radius: 5px;
+  border: 1px solid rgba(var(--fx-accent), 0.3);
+  background: transparent;
+  color: rgb(var(--fx-ink-dim));
+  font-size: 11px;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  cursor: pointer;
+  transition:
+    background 0.12s,
+    color 0.12s;
+}
+
+.share-seg-btn.active {
+  background: rgba(var(--fx-accent), 0.18);
+  color: rgb(var(--fx-ink));
+  border-color: rgba(var(--fx-accent), 0.6);
+}
+
+.share-seg-btn:hover:not(.active) {
+  background: rgba(var(--fx-accent), 0.07);
+  color: rgb(var(--fx-ink));
+}
+
+.share-generate-btn {
+  padding: 7px 14px;
+  border-radius: 6px;
+  border: 1px solid rgba(var(--fx-accent), 0.5);
+  background: rgba(var(--fx-accent), 0.12);
+  color: rgb(var(--fx-ink));
+  font-size: 12px;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.share-generate-btn:hover:not(:disabled) {
+  background: rgba(var(--fx-accent), 0.25);
+}
+
+.share-generate-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.share-result {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.share-link-row {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.share-link-input {
+  flex: 1;
+  min-width: 0;
+  padding: 5px 8px;
+  border-radius: 5px;
+  border: 1px solid rgba(var(--fx-accent), 0.3);
+  background: rgba(var(--fx-glass-bottom), 0.6);
+  color: rgb(var(--fx-ink));
+  font-size: 10px;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  outline: none;
+}
+
+.share-copy-btn {
+  flex-shrink: 0;
+  padding: 4px 12px;
+  border-radius: 5px;
+  border: 1px solid rgba(var(--fx-accent), 0.4);
+  background: transparent;
+  color: rgb(var(--fx-ink));
+  font-size: 11px;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  cursor: pointer;
+  transition:
+    background 0.12s,
+    color 0.12s;
+}
+
+.share-copy-btn:hover {
+  background: rgba(var(--fx-accent), 0.15);
+}
+
+.share-copy-btn.copied {
+  color: #4caf50;
+  border-color: rgba(76, 175, 80, 0.5);
+}
+
+.share-hint {
+  font-size: 11px;
+  color: rgb(var(--fx-ink-dim));
+  margin: 0;
+  line-height: 1.5;
+}
+
+.share-error {
+  font-size: 12px;
+  color: #ef5350;
+  padding: 8px 0;
+}
+</style>

--- a/src/helpers/CytoscapeRenderer.js
+++ b/src/helpers/CytoscapeRenderer.js
@@ -1062,6 +1062,25 @@ export default class CytoscapeRenderer {
     this._renderCrosshairs()
   }
 
+  setPeerSelections(peers) {
+    if (!this.cy) return
+    this.cy
+      .nodes()
+      .removeClass('peer-selected')
+      .removeStyle('underlay-color underlay-opacity underlay-padding')
+    for (const peer of Object.values(peers)) {
+      for (const nodeId of peer.selection || []) {
+        const el = this.cy.getElementById(nodeId)
+        if (el.empty()) continue
+        el.addClass('peer-selected').style({
+          'underlay-color': peer.color,
+          'underlay-opacity': 0.4,
+          'underlay-padding': 8
+        })
+      }
+    }
+  }
+
   selectNode(id) {
     this.cy?.elements()?.removeClass('focused')
     this.cy?.getElementById(id).addClass('focused')

--- a/src/helpers/DiagramGraph.js
+++ b/src/helpers/DiagramGraph.js
@@ -1,6 +1,8 @@
 import D3Util from '@/helpers/D3Util'
 import VueCookies from 'vue-cookies'
 import { modelToGraphlib } from '@/helpers/graphlibMigration'
+import api from '@/services/api'
+import { clientId as collabClientId } from '@/services/collab'
 
 export default class DiagramGraph {
   constructor(d3dInfo, emitter) {
@@ -150,6 +152,8 @@ export default class DiagramGraph {
 
     this.colaConstraints = d3dInfo.colaConstraints || []
     this.cy.colaConstraints = this.colaConstraints
+
+    this._saveTimer = null
   }
 
   // ─── Convenience counts ───────────────────────────────────────────────────────
@@ -427,8 +431,7 @@ export default class DiagramGraph {
       iconName: data.iconName,
       iconPosition: data.iconPosition,
       iconSize: data.iconSize,
-      iconColor: data.iconColor,
-      id
+      iconColor: data.iconColor
     }
   }
 
@@ -589,6 +592,7 @@ export default class DiagramGraph {
       dagreOpts: this.dagreOpts
     })
     this._saveTempDiagram()
+    this._scheduleServerSave()
   }
 
   setLayoutMode(mode) {
@@ -601,6 +605,34 @@ export default class DiagramGraph {
 
   reset() {
     if (this.renderer) this.renderer.resetCamera()
+  }
+
+  _scheduleServerSave() {
+    if (import.meta.env.VITE_COLLAB_ENABLED !== 'true') return
+    if (!this.d3dInfo?.id) return
+    try {
+      const claims = JSON.parse(atob((localStorage.getItem('token') || '').split('.')[1]))
+      if (claims.iss === 'd3d-share' && claims.role !== 'edit') return
+    } catch {
+      /* not a JWT — proceed */
+    }
+    clearTimeout(this._saveTimer)
+    this._saveTimer = setTimeout(() => this._serverSave(), 500)
+  }
+
+  async _serverSave() {
+    const json = modelToGraphlib(this.cy)
+    try {
+      await api.updateDiagram({
+        id: this.d3dInfo.id,
+        name: this.d3dInfo.name || D3Util.tempInfo().name,
+        description: this.d3dInfo.description || D3Util.tempInfo().description,
+        diagram: JSON.stringify(json),
+        clientId: collabClientId()
+      })
+    } catch (err) {
+      console.error('collab auto-save failed', err)
+    }
   }
 
   _saveTempDiagram() {

--- a/src/helpers/GraphKeys.js
+++ b/src/helpers/GraphKeys.js
@@ -10,6 +10,7 @@ import Shortcuts from '@/helpers/Shortcuts.js'
 //   { action: 'addNode' }                      { action: 'addEdge' }
 //   { action: 'edit', data, mode }             { action: 'delete' }
 //   { action: 'copy' }                         { action: 'history' }
+//   { action: 'share' }
 //   { action: 'close' }                        { action: 'select' }
 //   { action: 'nav', direction: 'j'|'k'|'h'|'l' }
 //   { action: 'showHints' }
@@ -44,6 +45,7 @@ export function resolveGraphKey(event, ctx) {
   if (S.matches(event, 'deleteElement')) return { action: 'delete' }
   if (S.matches(event, 'copyNode')) return { action: 'copy' }
   if (S.matches(event, 'history')) return { action: 'history' }
+  if (S.matches(event, 'share')) return { action: 'share' }
   if (S.matches(event, 'close')) return { action: 'close' }
   if (S.matches(event, 'select')) return { action: 'select' }
   if (S.matches(event, 'showHints')) return { action: 'showHints' }

--- a/src/helpers/Shortcuts.js
+++ b/src/helpers/Shortcuts.js
@@ -48,7 +48,8 @@ export const DEFAULT_SHORTCUTS = [
   { id: 'actionsMenu', group: 'graph', label: 'Open actions menu', mac: 'a', other: 'a' },
   { id: 'help', group: 'graph', label: 'Show help', mac: '/', other: '/' },
   { id: 'copyNode', group: 'graph', label: 'Copy focused node', mac: 'y', other: 'y' },
-  { id: 'history', group: 'graph', label: 'History panel', mac: 'shift+h', other: 'shift+h' }
+  { id: 'history', group: 'graph', label: 'History panel', mac: 'shift+h', other: 'shift+h' },
+  { id: 'share', group: 'graph', label: 'Share link dialog', mac: 'shift+s', other: 'shift+s' }
 ]
 
 // Combos owned by non-rebindable handlers (menu, palette, pan/zoom/layouts)

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ runLegacyMigrationOnce()
 
 import { createApp } from 'vue'
 import App from '@/App.vue'
-//import router from '@/router'
+import router from '@/router'
 // Vuetify
 import 'vuetify/styles'
 // HUD stylesheet — imported after Vuetify so our class rules beat Vuetify's
@@ -39,7 +39,7 @@ import VueCookies from 'vue-cookies'
 
 const app = createApp(App)
 // fixes the warning in the debugger
-//app.use(router)
+app.use(router)
 app.use(vuetify)
 app.use(VueCookies)
 app.component('FocusTrap', FocusTrap)

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,22 +1,13 @@
 import { createRouter, createWebHistory } from 'vue-router'
-//import HomeView from '../views/HomeView.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   routes: [
-  //  {
-  //    path: '/',
-  //    name: 'home',
-  //    component: HomeView
-  //  },
-  //  {
-  //    path: '/about',
-  //    name: 'about',
-  //    // route level code-splitting
-  //    // this generates a separate chunk (About.[hash].js) for this route
-  //    // which is lazy-loaded when the route is visited.
-  //    component: () => import('../views/AboutView.vue')
-  //  }
+    {
+      path: '/join/:token',
+      name: 'join',
+      component: () => import('@/components/JoinView.vue')
+    }
   ]
 })
 

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -6,92 +6,126 @@ function api() {
 }
 
 export default {
-  async auth (username, password) {
-    return api().post('/auth/login', {
-      username: username,
-      password: password,
-    })
-      .then(response => {
+  async auth(username, password) {
+    return api()
+      .post('/auth/login', {
+        username: username,
+        password: password
+      })
+      .then((response) => {
         return response
       })
-      .catch(error => {
+      .catch((error) => {
         return error
       })
   },
-  getOptions () {
+  getOptions() {
     // return axios.get('http://192.168.1.4:3000/menus_options',
-    return api().get('/menus',
-      { headers:
-        { Authorization: 'Bearer ' + localStorage.getItem('token') }
-      })
-      .then(response => {
+    return api()
+      .get('/menus', { headers: { Authorization: 'Bearer ' + localStorage.getItem('token') } })
+      .then((response) => {
         console.log(response)
         return response.data
       })
   },
-  async getDiagram (id) {
-    return api().get('/dag/' + id,
-      { headers:
-        { Authorization: 'Bearer ' + localStorage.getItem('token')
-        }
-      })
-      .then(response => {
+  async getDiagram(id) {
+    return api()
+      .get('/dag/' + id, { headers: { Authorization: 'Bearer ' + localStorage.getItem('token') } })
+      .then((response) => {
         return response.data
       })
-      .catch(error => {
+      .catch((error) => {
         return error
       })
       .finally(() => {
         console.log('getDiagram finished')
       })
   },
-  async getDiagrams () {
-    return api().get('/dags',
-      { headers:
-        { Authorization: 'Bearer ' + localStorage.getItem('token')
-        }
-      })
-      .then(response => {
+  async getDiagrams() {
+    return api()
+      .get('/dags', { headers: { Authorization: 'Bearer ' + localStorage.getItem('token') } })
+      .then((response) => {
         return response
       })
-      .catch(error => {
+      .catch((error) => {
         return error
       })
   },
-  async postDiagram (payload) {
-    return api().post('/dag', payload, {
-      headers: { Authorization: 'Bearer ' + localStorage.getItem('token') }
+  async postDiagram(payload) {
+    return api()
+      .post('/dag', payload, {
+        headers: { Authorization: 'Bearer ' + localStorage.getItem('token') }
       })
-      .then(response => {
+      .then((response) => {
         return response
       })
-      .catch(error => {
+      .catch((error) => {
         return error
       })
   },
-  async updateDiagram (data) {
-
-    return api().post('/dag/' + data.id + '/update', data,
-      { headers: { Authorization: 'Bearer ' + localStorage.getItem('token')
-        }
+  async updateDiagram(data) {
+    return api()
+      .post('/dag/' + data.id + '/update', data, {
+        headers: { Authorization: 'Bearer ' + localStorage.getItem('token') }
       })
-      .then(response => {
+      .then((response) => {
         return response
       })
-      .catch(error => {
+      .catch((error) => {
         return error
       })
   },
-  async deleteDiagram (id) {
+  async getHistory(dagId) {
+    return api()
+      .get('/dag/' + dagId + '/history', {
+        headers: { Authorization: 'Bearer ' + localStorage.getItem('token') }
+      })
+      .then((response) => response.data)
+      .catch((error) => error)
+  },
+  async restoreHistory(dagId, historyId) {
+    return api()
+      .post(
+        '/dag/' + dagId + '/history/' + historyId + '/restore',
+        {},
+        { headers: { Authorization: 'Bearer ' + localStorage.getItem('token') } }
+      )
+      .then((response) => response)
+      .catch((error) => error)
+  },
+  async createShare(dagId, req) {
+    return api()
+      .post('/dag/' + dagId + '/shares', req, {
+        headers: { Authorization: 'Bearer ' + localStorage.getItem('token') }
+      })
+      .then((response) => response.data)
+      .catch((error) => error)
+  },
+  async revokeShare(dagId, jti) {
+    return api()
+      .post(
+        '/dag/' + dagId + '/shares/' + jti + '/revoke',
+        {},
+        { headers: { Authorization: 'Bearer ' + localStorage.getItem('token') } }
+      )
+      .then((response) => response.data)
+      .catch((error) => error)
+  },
+  async exchangeShare(token) {
+    return api()
+      .get('/shares/exchange', { params: { token } })
+      .then((response) => response.data)
+      .catch((error) => error)
+  },
+  async deleteDiagram(id) {
     if (D3Util.debug) {
       console.log(id)
     }
-    return api().delete('/dag/' + id,
-      { headers:
-        { Authorization: 'Bearer ' + localStorage.getItem('token')
-        }
+    return api()
+      .delete('/dag/' + id, {
+        headers: { Authorization: 'Bearer ' + localStorage.getItem('token') }
       })
-      .then(response => {
+      .then((response) => {
         return response.data
       })
   }

--- a/src/services/collab.js
+++ b/src/services/collab.js
@@ -1,0 +1,114 @@
+import D3Util from '@/helpers/D3Util'
+
+const CLIENT_ID_KEY = 'd3d_collab_client_id'
+
+function getClientId() {
+  let id = sessionStorage.getItem(CLIENT_ID_KEY)
+  if (!id) {
+    id = crypto.randomUUID()
+    sessionStorage.setItem(CLIENT_ID_KEY, id)
+  }
+  return id
+}
+
+function wsUrl(dagId) {
+  const base = D3Util.serverUrl().replace(/^http/, 'ws')
+  const token = localStorage.getItem('token')
+  return `${base}/dag/${dagId}/ws?token=${encodeURIComponent(token ?? '')}`
+}
+
+const BACKOFF_BASE = 100
+const BACKOFF_MAX = 30_000
+
+let socket = null
+let dagId = null
+let reconnectTimer = null
+let attempt = 0
+let intentionalClose = false
+
+const handlers = {
+  diagramUpdated: null,
+  presence: null,
+  statusChange: null
+}
+
+function scheduleReconnect() {
+  if (intentionalClose) return
+  const delay = Math.min(BACKOFF_BASE * 2 ** attempt + Math.random() * 100, BACKOFF_MAX)
+  attempt++
+  reconnectTimer = setTimeout(() => openSocket(), delay)
+}
+
+function openSocket() {
+  if (!dagId) return
+  socket = new WebSocket(wsUrl(dagId))
+
+  socket.addEventListener('open', () => {
+    attempt = 0
+    handlers.statusChange?.('connected')
+  })
+
+  socket.addEventListener('message', ({ data }) => {
+    let msg
+    try {
+      msg = JSON.parse(data)
+    } catch {
+      return
+    }
+
+    if (msg.clientId === getClientId()) return
+
+    if (msg.type === 'diagram:updated') {
+      handlers.diagramUpdated?.(msg)
+    } else if (msg.type === 'presence') {
+      handlers.presence?.(msg)
+    }
+  })
+
+  socket.addEventListener('close', () => {
+    handlers.statusChange?.('disconnected')
+    scheduleReconnect()
+  })
+
+  socket.addEventListener('error', () => {
+    socket.close()
+  })
+}
+
+export function connect(id) {
+  disconnect()
+  dagId = id
+  intentionalClose = false
+  attempt = 0
+  openSocket()
+}
+
+export function disconnect() {
+  intentionalClose = true
+  clearTimeout(reconnectTimer)
+  reconnectTimer = null
+  if (socket) {
+    socket.close()
+    socket = null
+  }
+  dagId = null
+}
+
+export function sendPresence(state) {
+  if (socket?.readyState !== WebSocket.OPEN) return
+  socket.send(JSON.stringify({ type: 'presence', clientId: getClientId(), ...state }))
+}
+
+export function onDiagramUpdated(cb) {
+  handlers.diagramUpdated = cb
+}
+export function onPresence(cb) {
+  handlers.presence = cb
+}
+export function onStatusChange(cb) {
+  handlers.statusChange = cb
+}
+
+export function clientId() {
+  return getClientId()
+}

--- a/src/services/collab.test.js
+++ b/src/services/collab.test.js
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('@/helpers/D3Util', () => ({
+  default: { serverUrl: () => 'http://localhost:3000' }
+}))
+
+// ── WebSocket mock ────────────────────────────────────────────────────────────
+
+class MockWebSocket {
+  constructor(url) {
+    this.url = url
+    this.readyState = MockWebSocket.CONNECTING
+    this._listeners = {}
+    this._sent = []
+    MockWebSocket.latest = this
+    MockWebSocket.instances.push(this)
+  }
+
+  addEventListener(event, fn) {
+    ;(this._listeners[event] ??= []).push(fn)
+  }
+
+  send(data) {
+    this._sent.push(data)
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED
+    this._emit('close', {})
+  }
+
+  _emit(event, data) {
+    ;(this._listeners[event] ?? []).forEach((fn) => fn(data))
+  }
+
+  _open() {
+    this.readyState = MockWebSocket.OPEN
+    this._emit('open', {})
+  }
+
+  _message(payload) {
+    this._emit('message', { data: JSON.stringify(payload) })
+  }
+
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+  static instances = []
+  static latest = null
+
+  static reset() {
+    this.instances = []
+    this.latest = null
+  }
+}
+
+// ── Storage mocks ─────────────────────────────────────────────────────────────
+
+function makeStorage() {
+  const store = {}
+  return {
+    getItem: (k) => store[k] ?? null,
+    setItem: (k, v) => {
+      store[k] = String(v)
+    },
+    removeItem: (k) => {
+      delete store[k]
+    },
+    clear: () => {
+      Object.keys(store).forEach((k) => delete store[k])
+    }
+  }
+}
+
+// ── Setup / teardown ──────────────────────────────────────────────────────────
+
+let collab
+
+beforeEach(async () => {
+  MockWebSocket.reset()
+  vi.useFakeTimers()
+
+  vi.stubGlobal('WebSocket', MockWebSocket)
+  vi.stubGlobal('sessionStorage', makeStorage())
+  vi.stubGlobal('localStorage', makeStorage())
+  vi.stubGlobal('crypto', { randomUUID: () => 'test-client-id' })
+
+  localStorage.setItem('token', 'header.eyJ1c2VybmFtZSI6InRlc3QifQ.sig') // gitleaks:allow
+  sessionStorage.setItem('d3d_collab_client_id', 'test-client-id')
+
+  // Fresh module import each test so module-level state is reset
+  vi.resetModules()
+  collab = await import('@/services/collab')
+})
+
+afterEach(() => {
+  collab.disconnect()
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('collab.connect', () => {
+  it('opens a WebSocket with ws:// URL and token', () => {
+    collab.connect('dag-1')
+    expect(MockWebSocket.instances).toHaveLength(1)
+    const ws = MockWebSocket.latest
+    expect(ws.url).toBe(
+      'ws://localhost:3000/dag/dag-1/ws?token=header.eyJ1c2VybmFtZSI6InRlc3QifQ.sig' // gitleaks:allow
+    )
+  })
+
+  it('closes the previous socket when called again', () => {
+    collab.connect('dag-1')
+    const first = MockWebSocket.latest
+    collab.connect('dag-2')
+    expect(first.readyState).toBe(MockWebSocket.CLOSED)
+    expect(MockWebSocket.instances).toHaveLength(2)
+  })
+})
+
+describe('echo prevention', () => {
+  it('ignores messages with own clientId', () => {
+    const cb = vi.fn()
+    collab.onDiagramUpdated(cb)
+    collab.connect('dag-1')
+    MockWebSocket.latest._open()
+    MockWebSocket.latest._message({
+      type: 'diagram:updated',
+      clientId: 'test-client-id',
+      nodes: []
+    })
+    expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('delivers messages from a different clientId', () => {
+    const cb = vi.fn()
+    collab.onDiagramUpdated(cb)
+    collab.connect('dag-1')
+    MockWebSocket.latest._open()
+    MockWebSocket.latest._message({ type: 'diagram:updated', clientId: 'other-client', nodes: [] })
+    expect(cb).toHaveBeenCalledOnce()
+    expect(cb.mock.calls[0][0]).toMatchObject({ type: 'diagram:updated', clientId: 'other-client' })
+  })
+})
+
+describe('onPresence', () => {
+  it('fires for presence messages from remote peers', () => {
+    const cb = vi.fn()
+    collab.onPresence(cb)
+    collab.connect('dag-1')
+    MockWebSocket.latest._open()
+    MockWebSocket.latest._message({
+      type: 'presence',
+      clientId: 'peer-1',
+      displayName: 'Alice',
+      color: '#ef5350',
+      selection: ['n1']
+    })
+    expect(cb).toHaveBeenCalledOnce()
+    expect(cb.mock.calls[0][0]).toMatchObject({ clientId: 'peer-1', displayName: 'Alice' })
+  })
+
+  it('does not fire for own presence messages', () => {
+    const cb = vi.fn()
+    collab.onPresence(cb)
+    collab.connect('dag-1')
+    MockWebSocket.latest._open()
+    MockWebSocket.latest._message({
+      type: 'presence',
+      clientId: 'test-client-id',
+      displayName: 'Me'
+    })
+    expect(cb).not.toHaveBeenCalled()
+  })
+})
+
+describe('onStatusChange', () => {
+  it('emits connected on open', () => {
+    const cb = vi.fn()
+    collab.onStatusChange(cb)
+    collab.connect('dag-1')
+    MockWebSocket.latest._open()
+    expect(cb).toHaveBeenCalledWith('connected')
+  })
+
+  it('emits disconnected on close', () => {
+    const cb = vi.fn()
+    collab.onStatusChange(cb)
+    collab.connect('dag-1')
+    MockWebSocket.latest._open()
+    MockWebSocket.latest.close()
+    expect(cb).toHaveBeenCalledWith('disconnected')
+  })
+})
+
+describe('reconnect', () => {
+  it('schedules reconnect after unintentional close', () => {
+    collab.connect('dag-1')
+    MockWebSocket.latest._open()
+    MockWebSocket.latest.close()
+    expect(MockWebSocket.instances).toHaveLength(1)
+    vi.runAllTimers()
+    expect(MockWebSocket.instances).toHaveLength(2)
+  })
+
+  it('does not reconnect after disconnect()', () => {
+    collab.connect('dag-1')
+    MockWebSocket.latest._open()
+    collab.disconnect()
+    vi.runAllTimers()
+    expect(MockWebSocket.instances).toHaveLength(1)
+  })
+})
+
+describe('sendPresence', () => {
+  it('sends presence JSON when socket is open', () => {
+    collab.connect('dag-1')
+    const ws = MockWebSocket.latest
+    ws._open()
+    collab.sendPresence({ displayName: 'Alice', color: '#ef5350', selection: ['n1'] })
+    expect(ws._sent).toHaveLength(1)
+    const msg = JSON.parse(ws._sent[0])
+    expect(msg).toMatchObject({
+      type: 'presence',
+      clientId: 'test-client-id',
+      displayName: 'Alice',
+      color: '#ef5350',
+      selection: ['n1']
+    })
+  })
+
+  it('is a no-op when socket is not open', () => {
+    collab.connect('dag-1')
+    const ws = MockWebSocket.latest
+    // socket stays in CONNECTING state
+    collab.sendPresence({ displayName: 'Alice', color: '#ef5350', selection: [] })
+    expect(ws._sent).toHaveLength(0)
+  })
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,12 +5,14 @@ import vue from '@vitejs/plugin-vue'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [
-    vue(),
-  ],
+  plugins: [vue()],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))
     }
+  },
+  test: {
+    globals: true,
+    environment: 'node'
   }
 })


### PR DESCRIPTION
## Summary
Curated merge of the production collaboration work from `feat/collab-phase0` into main. POC artifacts (spike Go relay binary, CollabPoc/CollabCytoPoc components, yjs deps, POC routes) are excluded.

## What's included
- **Realtime WS collab service** — `collab.js` with presence, echo prevention via clientId, exponential backoff reconnect
- **Auto-save** — debounced (500ms) server saves gated on `VITE_COLLAB_ENABLED`
- **History panel** — snapshot list + restore (`Shift+H`), wired via `diagram:reload`
- **Share links** — `ShareDialog.vue` (`Shift+S`), `/join/:token` route, `JoinView.vue` exchange
- **View-only enforcement** — read-only UI + no server saves for `role=view` share tokens
- **Feature flag** — `VITE_COLLAB_ENABLED` defaults to false in `.env`

## Merge conflicts resolved
Kept main's newer icon/none-shape additions (commits on main after phase0 branched) merged with the collab changes rather than reverting them.

## Verification
- `vite build` passes
- 243 unit tests pass (13 files)

> Note: the backend endpoints (WS relay, history, shares, exchange) live on `feat/collab-phase2` in d3d-api and are required for these features to function end-to-end.