### PR TITLE
feat(diagram): local autosave on change and browser snapshot history

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -319,6 +319,10 @@ export default {
       if (id) this.loadFromServer(id)
     })
 
+    this.emitter.on('diagram:restore-local', (snapshot) => {
+      this.restoreLocal(snapshot)
+    })
+
     this.emitter.on('diagram:updated-remote', () => {
       const id = this.d3dInfo?.id
       if (id) this.loadFromServer(id)
@@ -530,6 +534,30 @@ export default {
     runCommand(cmd) {
       this.closeCommandPalette()
       this.d3Action(cmd.title)
+    },
+    restoreLocal(snapshot) {
+      try {
+        const parsed = migrateDiagramPayload(JSON.parse(snapshot.diagram))
+        const model = markRaw(
+          isGraphlibFormat(parsed) ? graphlibToModel(parsed) : new GraphModel(parsed)
+        )
+        model.colaConstraints = parsed.options?.constraints || []
+        this.d3dInfo = {
+          ...this.d3dInfo,
+          name: snapshot.name ?? this.d3dInfo?.name,
+          description: snapshot.description ?? this.d3dInfo?.description,
+          diagram: model,
+          colaConstraints: model.colaConstraints
+        }
+        this.modifier = markRaw(new DiagramGraph(this.d3dInfo, this.emitter))
+        this.emitter.emit('appMessage', { message: 'Snapshot restored', status: 'success' })
+      } catch (err) {
+        console.error('local restore failed', err)
+        this.emitter.emit('appMessage', {
+          message: 'Unable to restore this snapshot',
+          status: 'error'
+        })
+      }
     },
     d3Action: async function (event) {
       MenuLinks.Click(event, this)

--- a/src/components/DiagramForm.vue
+++ b/src/components/DiagramForm.vue
@@ -451,6 +451,7 @@ import GraphModel from '@/helpers/GraphModel.js'
 import DiagramGraph from '@/helpers/DiagramGraph.js'
 import { modelToGraphlib, graphlibToModel, isGraphlibFormat } from '@/helpers/graphlibMigration.js'
 import D3DApi from '@/services/api'
+import { clearHistory } from '@/services/localHistory.js'
 
 export default {
   name: 'DiagramForm',
@@ -696,6 +697,7 @@ export default {
 
     newDiagram() {
       this.$cookies.remove('LastLocallySavedItemId')
+      clearHistory(null)
 
       const settings = this.$cookies.get('settings') || D3Util.appDefaults()
       const defaults = D3Util.appDefaults()

--- a/src/components/DiagramGraphView.vue
+++ b/src/components/DiagramGraphView.vue
@@ -92,7 +92,7 @@
       <transition name="fx-panel">
         <div v-if="showHistory" class="fx-hud-stage">
           <HistoryPanel
-            :dagId="(modifier?.value ?? modifier)?.d3dInfo?.id"
+            :dagId="(modifier?.value ?? modifier)?.d3dInfo?.id || 'unsaved'"
             @close="showHistory = false"
             @restored="onHistoryRestored"
           />
@@ -527,7 +527,7 @@ export default {
             break
           }
           case 'history':
-            if (mod?.d3dInfo?.id) this.showHistory = true
+            if (mod) this.showHistory = true
             break
           case 'close':
             if (this.escCount >= 2) this.resetValues()
@@ -562,8 +562,12 @@ export default {
         .toUpperCase()
     },
 
-    onHistoryRestored() {
+    onHistoryRestored(payload) {
       this.showHistory = false
+      if (payload?.source === 'local') {
+        this.emitter.emit('diagram:restore-local', payload.snapshot)
+        return
+      }
       const mod = this.modifier?.value ?? this.modifier
       const id = mod?.d3dInfo?.id
       if (id) this.emitter.emit('diagram:reload', id)

--- a/src/components/HistoryPanel.vue
+++ b/src/components/HistoryPanel.vue
@@ -15,15 +15,23 @@
         <div class="fx-panel-body">
           <div v-if="loading" class="hist-loading">Loading…</div>
 
-          <div v-else-if="entries.length === 0" class="hist-empty">No history yet.</div>
+          <div v-else-if="entries.length === 0" class="hist-empty">
+            No history yet — snapshots are saved automatically as you edit.
+          </div>
 
           <ul v-else class="hist-list">
-            <li v-for="entry in entries" :key="entry.id" class="hist-entry">
+            <li v-for="entry in entries" :key="entry.source + entry.id" class="hist-entry">
               <div class="hist-meta">
                 <span class="hist-time" :title="entry.savedAt">{{
                   formatTime(entry.savedAt)
                 }}</span>
-                <span v-if="entry.savedBy" class="hist-user">{{ entry.savedBy }}</span>
+                <span class="hist-subline">
+                  <span class="hist-chip" :class="entry.source === 'server' ? 'hist-chip-server' : 'hist-chip-local'">{{
+                    entry.source === 'server' ? 'SERVER' : 'LOCAL'
+                  }}</span>
+                  <span v-if="entry.savedBy" class="hist-user">{{ entry.savedBy }}</span>
+                  <span v-else-if="entry.name" class="hist-name">{{ entry.name }}</span>
+                </span>
               </div>
               <button
                 class="hist-restore-btn"
@@ -57,6 +65,8 @@
 
 <script>
 import api from '@/services/api'
+import D3Util from '@/helpers/D3Util'
+import { getHistory, getSnapshot } from '@/services/localHistory'
 
 export default {
   name: 'HistoryPanel',
@@ -78,16 +88,33 @@ export default {
     await this.fetchHistory()
   },
   methods: {
+    _serverAvailable() {
+      // 'unsaved' is the browser-only history bucket — never a server dag id.
+      return D3Util.auth() && !!this.dagId && this.dagId !== 'unsaved'
+    },
+
     async fetchHistory() {
       this.loading = true
-      try {
-        const data = await api.getHistory(this.dagId)
-        this.entries = data?.history ?? []
-      } catch {
-        this.entries = []
-      } finally {
-        this.loading = false
+      const local = getHistory(this.dagId).map((entry) => ({
+        ...entry,
+        source: 'local'
+      }))
+
+      let server = []
+      if (this._serverAvailable()) {
+        try {
+          const data = await api.getHistory(this.dagId)
+          server = (data?.history ?? []).map((entry) => ({ ...entry, source: 'server' }))
+        } catch {
+          // Server unreachable — local snapshots still available.
+          server = []
+        }
       }
+
+      this.entries = [...local, ...server].sort(
+        (a, b) => new Date(b.savedAt) - new Date(a.savedAt)
+      )
+      this.loading = false
     },
 
     confirmRestore(entry) {
@@ -98,10 +125,20 @@ export default {
       this.confirmEntry = null
       this.restoring = entry.id
       try {
-        await api.restoreHistory(this.dagId, entry.id)
-        this.$emit('restored')
-      } catch {
-        // silent — parent will handle via reload
+        if (entry.source === 'server') {
+          await api.restoreHistory(this.dagId, entry.id)
+          this.$emit('restored', { source: 'server' })
+        } else {
+          const snapshot = getSnapshot(this.dagId, entry.id)
+          if (!snapshot) throw new Error('local snapshot missing')
+          this.$emit('restored', { source: 'local', snapshot })
+        }
+      } catch (err) {
+        this.emitter?.emit('appMessage', {
+          message: 'Unable to restore this snapshot',
+          status: 'error'
+        })
+        console.error('history restore failed', err)
       } finally {
         this.restoring = null
       }
@@ -170,12 +207,47 @@ export default {
   white-space: nowrap;
 }
 
+.hist-subline {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.hist-chip {
+  flex-shrink: 0;
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+}
+
+.hist-chip-local {
+  color: rgb(var(--fx-ink));
+  border: 1px solid rgba(var(--fx-accent), 0.4);
+}
+
+.hist-chip-server {
+  color: #fff;
+  background: rgba(var(--fx-accent), 0.55);
+}
+
 .hist-user {
   font-size: 10px;
   color: rgb(var(--fx-ink-dim));
-  truncate: ellipsis;
   white-space: nowrap;
   overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.hist-name {
+  font-size: 10px;
+  color: rgb(var(--fx-ink-dim));
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .hist-restore-btn {

--- a/src/helpers/DiagramGraph.js
+++ b/src/helpers/DiagramGraph.js
@@ -3,6 +3,7 @@ import VueCookies from 'vue-cookies'
 import { modelToGraphlib } from '@/helpers/graphlibMigration'
 import api from '@/services/api'
 import { clientId as collabClientId } from '@/services/collab'
+import { pushSnapshot } from '@/services/localHistory'
 
 export default class DiagramGraph {
   constructor(d3dInfo, emitter) {
@@ -591,8 +592,9 @@ export default class DiagramGraph {
       concentricOpts: this.concentricOpts,
       dagreOpts: this.dagreOpts
     })
-    this._saveTempDiagram()
-    this._scheduleServerSave()
+    // Pan/zoom are view-only ops — nothing to persist.
+    if (options.pan || options.zoom) return
+    this._persist()
   }
 
   setLayoutMode(mode) {
@@ -607,31 +609,67 @@ export default class DiagramGraph {
     if (this.renderer) this.renderer.resetCamera()
   }
 
-  _scheduleServerSave() {
-    if (import.meta.env.VITE_COLLAB_ENABLED !== 'true') return
-    if (!this.d3dInfo?.id) return
+  _isViewOnly() {
     try {
       const claims = JSON.parse(atob((localStorage.getItem('token') || '').split('.')[1]))
-      if (claims.iss === 'd3d-share' && claims.role !== 'edit') return
+      return claims.iss === 'd3d-share' && claims.role !== 'edit'
     } catch {
-      /* not a JWT — proceed */
+      /* not a JWT — editable */
+      return false
     }
-    clearTimeout(this._saveTimer)
-    this._saveTimer = setTimeout(() => this._serverSave(), 500)
   }
 
-  async _serverSave() {
+  // Persist every diagram change: the browser draft + real localStorage entry
+  // are written synchronously (cheap, crash-safe), history snapshots are
+  // coalesced by localHistory, and the server write is debounced.
+  _persist() {
+    if (this._isViewOnly()) return
+    this._saveTempDiagram()
+
     const json = modelToGraphlib(this.cy)
-    try {
-      await api.updateDiagram({
-        id: this.d3dInfo.id,
-        name: this.d3dInfo.name || D3Util.tempInfo().name,
-        description: this.d3dInfo.description || D3Util.tempInfo().description,
-        diagram: JSON.stringify(json),
-        clientId: collabClientId()
+    const diagram = JSON.stringify(json)
+    const id = this.d3dInfo?.id
+    const name = this.d3dInfo?.name || D3Util.tempInfo().name
+    const description = this.d3dInfo?.description || D3Util.tempInfo().description
+
+    if (id) {
+      D3Util.updateLocalEntry({
+        id,
+        name,
+        description,
+        diagram: this.cy,
+        created: this.d3dInfo.created
       })
+    }
+
+    pushSnapshot(id, { name, description, diagram })
+
+    this._scheduleServerSave(diagram)
+  }
+
+  _scheduleServerSave(diagram) {
+    if (!D3Util.auth()) return
+    if (!this.d3dInfo?.id) return
+    clearTimeout(this._saveTimer)
+    this._saveTimer = setTimeout(() => this._serverSave(diagram), 800)
+  }
+
+  async _serverSave(diagram) {
+    const payload = {
+      id: this.d3dInfo.id,
+      name: this.d3dInfo.name || D3Util.tempInfo().name,
+      description: this.d3dInfo.description || D3Util.tempInfo().description,
+      diagram
+    }
+    // Collab keeps the clientId so the WebSocket echo of our own write is
+    // ignored; the manual-save path posts without it, so mirror that here.
+    if (import.meta.env.VITE_COLLAB_ENABLED === 'true') {
+      payload.clientId = collabClientId()
+    }
+    try {
+      await api.updateDiagram(payload)
     } catch (err) {
-      console.error('collab auto-save failed', err)
+      console.error('auto-save failed', err)
     }
   }
 

--- a/src/helpers/DiagramGraph.test.js
+++ b/src/helpers/DiagramGraph.test.js
@@ -1,9 +1,13 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import GraphModel from '@/helpers/GraphModel.js'
 import DiagramGraph from '@/helpers/DiagramGraph.js'
 
 vi.mock('vue-cookies', () => ({
   default: { get: () => null, set: () => {}, config: () => {} }
+}))
+
+vi.mock('@/services/api', () => ({
+  default: { updateDiagram: vi.fn().mockResolvedValue({}) }
 }))
 
 vi.stubGlobal('localStorage', {
@@ -552,5 +556,97 @@ describe('icon round-trip on edges', () => {
     expect(d.iconSet).toBe('material-symbols')
     expect(d.iconName).toBe('bolt')
     expect(d.iconPosition).toBe('only')
+  })
+})
+
+describe('autosave persistence', () => {
+  let api
+
+  beforeEach(async () => {
+    localStorage.store.clear()
+    localStorage.removeItem('token')
+    vi.useFakeTimers()
+    api = (await import('@/services/api')).default
+    api.updateDiagram.mockClear()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllEnvs()
+  })
+
+  function savedGraph() {
+    const model = new GraphModel([{ group: 'nodes', data: { id: 'n0', label: 'N' } }])
+    const graph = new DiagramGraph(
+      { diagram: model, name: 'D', description: 'desc', id: 'dag-1', created: '2026-01-01T00:00:00Z' },
+      { emit: vi.fn() }
+    )
+    graph.renderer = { updateScene: vi.fn(), selectNode: vi.fn(), deselectNode: vi.fn() }
+    return graph
+  }
+
+  it('writes the id-keyed localStorage entry and a history snapshot on change', () => {
+    const graph = savedGraph()
+    graph.redraw()
+
+    const entry = JSON.parse(localStorage.getItem('dag-1'))
+    expect(entry.name).toBe('D')
+    expect(entry.diagram).toContain('"label":"N"')
+
+    const history = JSON.parse(localStorage.getItem('d3d.history.dag-1'))
+    expect(history).toHaveLength(1)
+    expect(history[0].diagram).toContain('"label":"N"')
+  })
+
+  it('writes only the temp slot for an unsaved (no id) diagram', () => {
+    const { graph } = makeGraph(1)
+    graph.redraw()
+
+    expect(localStorage.getItem('dag-1')).toBeNull()
+    expect(localStorage.getItem('samus.lastUpdated')).not.toBeNull()
+    const history = JSON.parse(localStorage.getItem('d3d.history.unsaved'))
+    expect(history).toHaveLength(1)
+  })
+
+  it('skips persistence for pan/zoom redraws', () => {
+    const graph = savedGraph()
+    graph.redraw({ pan: 'Down' })
+
+    expect(localStorage.getItem('dag-1')).toBeNull()
+    expect(localStorage.getItem('d3d.history.dag-1')).toBeNull()
+  })
+
+  it('skips persistence for view-only share tokens', () => {
+    const graph = savedGraph()
+    const payload = btoa(JSON.stringify({ iss: 'd3d-share', role: 'view' }))
+    localStorage.setItem('token', `header.${payload}.sig`)
+    graph.redraw()
+
+    expect(localStorage.getItem('dag-1')).toBeNull()
+    expect(localStorage.getItem('d3d.history.dag-1')).toBeNull()
+  })
+
+  it('posts to the server (debounced) when logged in with a saved id', async () => {
+    vi.stubEnv('VITE_COLLAB_ENABLED', 'false')
+    const graph = savedGraph()
+    localStorage.setItem('token', 'a.b.c')
+
+    graph.redraw()
+    expect(api.updateDiagram).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(800)
+    expect(api.updateDiagram).toHaveBeenCalledTimes(1)
+    const payload = api.updateDiagram.mock.calls[0][0]
+    expect(payload.id).toBe('dag-1')
+    expect(payload.name).toBe('D')
+    expect(payload.diagram).toContain('"label":"N"')
+  })
+
+  it('does not post to the server without a token', async () => {
+    vi.stubEnv('VITE_COLLAB_ENABLED', 'false')
+    const graph = savedGraph()
+    graph.redraw()
+    await vi.advanceTimersByTimeAsync(800)
+    expect(api.updateDiagram).not.toHaveBeenCalled()
   })
 })

--- a/src/services/localHistory.js
+++ b/src/services/localHistory.js
@@ -1,0 +1,107 @@
+/**
+ * Browser-local diagram history.
+ *
+ * Keeps a capped list of snapshots per diagram in localStorage so the History
+ * panel can revert to earlier states without the RethinkDB-backed server.
+ * Snapshots are the same graphlib JSON the server/local entries store, so a
+ * restored snapshot can be fed straight through the normal load path.
+ */
+
+const PREFIX = 'd3d.history.'
+const UNSAVED_KEY = 'unsaved'
+const MAX_SNAPSHOTS = 50
+const MIN_SNAPSHOT_GAP_MS = 3000
+
+function historyKey(diagramId) {
+  return PREFIX + (diagramId || UNSAVED_KEY)
+}
+
+function read(key) {
+  try {
+    const raw = localStorage.getItem(key)
+    const list = raw ? JSON.parse(raw) : []
+    return Array.isArray(list) ? list : []
+  } catch (err) {
+    console.error('localHistory read failed', err)
+    return []
+  }
+}
+
+function write(key, list) {
+  try {
+    localStorage.setItem(key, JSON.stringify(list))
+  } catch (err) {
+    // Quota exceeded — drop the oldest snapshot and retry once.
+    if (list.length > 1) {
+      list.shift()
+      try {
+        localStorage.setItem(key, JSON.stringify(list))
+        return
+      } catch (e) {
+        /* still too big — give up quietly */
+      }
+    }
+    console.error('localHistory write failed', err)
+  }
+}
+
+function snapshotId() {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) return crypto.randomUUID()
+  return Date.now().toString(36) + Math.random().toString(36).slice(2, 10)
+}
+
+/**
+ * Append a snapshot for the diagram. Returns the new snapshot count, or 0 when
+ * the snapshot was skipped (identical to the last one, or within the min gap).
+ */
+export function pushSnapshot(diagramId, { name, description, diagram, savedBy } = {}) {
+  const key = historyKey(diagramId)
+  const list = read(key)
+
+  const last = list[list.length - 1]
+  if (last) {
+    if (last.diagram === diagram) return 0
+    const gap = Date.now() - new Date(last.savedAt).getTime()
+    if (gap < MIN_SNAPSHOT_GAP_MS) return 0
+  }
+
+  const entry = {
+    id: snapshotId(),
+    savedAt: new Date().toISOString(),
+    name,
+    description,
+    savedBy,
+    diagram
+  }
+  list.push(entry)
+  while (list.length > MAX_SNAPSHOTS) list.shift()
+  write(key, list)
+  return list.length
+}
+
+/** Snapshot list for the panel — heavy diagram payloads stripped. */
+export function getHistory(diagramId) {
+  return read(historyKey(diagramId)).map((e) => {
+    const meta = { ...e }
+    delete meta.diagram
+    return meta
+  })
+}
+
+/** Full snapshot (including diagram JSON) for restore, or null. */
+export function getSnapshot(diagramId, snapshotId) {
+  const entry = read(historyKey(diagramId)).find((e) => e.id === snapshotId)
+  return entry || null
+}
+
+export function clearHistory(diagramId) {
+  try {
+    localStorage.removeItem(historyKey(diagramId))
+  } catch (err) {
+    console.error('localHistory clear failed', err)
+  }
+}
+
+export function historyKeyFor(diagramId) {
+  return historyKey(diagramId)
+}

--- a/src/services/localHistory.test.js
+++ b/src/services/localHistory.test.js
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  pushSnapshot,
+  getHistory,
+  getSnapshot,
+  clearHistory,
+  historyKeyFor
+} from '@/services/localHistory.js'
+
+const store = new Map()
+
+vi.stubGlobal('localStorage', {
+  getItem: (k) => store.get(k) ?? null,
+  setItem: (k, v) => {
+    store.set(k, String(v))
+  },
+  removeItem: (k) => {
+    store.delete(k)
+  }
+})
+
+beforeEach(() => {
+  store.clear()
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+const payload = (label) => ({ name: 'D', description: 'x', diagram: JSON.stringify({ nodes: [{ v: 'n1', value: { label } }], edges: [] }) })
+
+describe('pushSnapshot / getHistory', () => {
+  it('appends a snapshot under the diagram key', () => {
+    const count = pushSnapshot('dag-1', payload('a'))
+    expect(count).toBe(1)
+
+    const entries = getHistory('dag-1')
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({ savedAt: '2026-01-01T00:00:00.000Z' })
+    expect(entries[0].diagram).toBeUndefined()
+  })
+
+  it('falls back to the unsaved key when diagramId is missing', () => {
+    pushSnapshot(null, payload('a'))
+    vi.setSystemTime(new Date('2026-01-01T00:00:10Z'))
+    pushSnapshot(undefined, payload('b'))
+    expect(getHistory(null)).toHaveLength(2)
+    expect(historyKeyFor(null)).toBe('d3d.history.unsaved')
+  })
+
+  it('skips a snapshot identical to the last one', () => {
+    pushSnapshot('dag-1', payload('a'))
+    const count = pushSnapshot('dag-1', payload('a'))
+    expect(count).toBe(0)
+    expect(getHistory('dag-1')).toHaveLength(1)
+  })
+
+  it('skips snapshots within the min gap', () => {
+    pushSnapshot('dag-1', payload('a'))
+    vi.setSystemTime(new Date('2026-01-01T00:00:01Z'))
+    const count = pushSnapshot('dag-1', payload('b'))
+    expect(count).toBe(0)
+    expect(getHistory('dag-1')).toHaveLength(1)
+  })
+
+  it('records a snapshot again after the min gap', () => {
+    pushSnapshot('dag-1', payload('a'))
+    vi.setSystemTime(new Date('2026-01-01T00:00:10Z'))
+    const count = pushSnapshot('dag-1', payload('b'))
+    expect(count).toBe(2)
+  })
+
+  it('caps the list at MAX_SNAPSHOTS and drops the oldest', () => {
+    for (let i = 0; i < 60; i++) {
+      vi.setSystemTime(new Date(2026, 0, 1, 0, 0, i * 4))
+      pushSnapshot('dag-1', payload('node-' + i))
+    }
+    const entries = getHistory('dag-1')
+    expect(entries).toHaveLength(50)
+    expect(entries[0].diagram).toBeUndefined()
+  })
+
+  it('tolerates corrupt stored data', () => {
+    store.set('d3d.history.dag-1', 'not json')
+    expect(getHistory('dag-1')).toEqual([])
+    expect(pushSnapshot('dag-1', payload('a'))).toBe(1)
+  })
+})
+
+describe('getSnapshot', () => {
+  it('returns the full payload for a known id', () => {
+    pushSnapshot('dag-1', payload('a'))
+    const entry = getHistory('dag-1')[0]
+    const snap = getSnapshot('dag-1', entry.id)
+    expect(snap.diagram).toContain('"label":"a"')
+    expect(snap.name).toBe('D')
+  })
+
+  it('returns null for an unknown id', () => {
+    pushSnapshot('dag-1', payload('a'))
+    expect(getSnapshot('dag-1', 'nope')).toBeNull()
+  })
+})
+
+describe('clearHistory', () => {
+  it('removes the diagram history key', () => {
+    pushSnapshot('dag-1', payload('a'))
+    clearHistory('dag-1')
+    expect(getHistory('dag-1')).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Adds two closely related features — both work fully offline with no RethinkDB or backend required.

### Autosave on change
Every structural diagram edit (add/delete/update node or edge, layout change) now automatically persists without requiring Alt+S:
- Writes `samus.lastUpdated` draft slot synchronously on every change (crash-safe)
- Writes the real localStorage entry keyed by diagram id (same format DiagramList already reads)
- Debounces a server POST at 800ms when the user is logged in
- Skips persistence on pan/zoom-only redraws and view-only share tokens

### Browser snapshot history (no RethinkDB)
- New `src/services/localHistory.js`: per-diagram localStorage snapshot store (up to 50 entries, deduplicated by content, minimum 3s gap between snapshots, QuotaExceededError safe)
- History panel now loads local snapshots always — no login or backend needed
- When logged in, server history is also fetched and merged, sorted newest-first with LOCAL/SERVER chips per entry
- Local restore applies the snapshot directly to the running modifier — no server round-trip
- Shift+H now opens the history panel even for unsaved diagrams
- `newDiagram()` clears the unsaved-draft history so old entries don't carry over

## Tests
- 259/259 passing, lint clean
- New: `localHistory.test.js` (10 tests), autosave tests added to `DiagramGraph.test.js`