### PR TITLE
chore: enable collab in production and keep machine alive for WebSockets

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -7,13 +7,16 @@ app = 'd3dweb'
 primary_region = 'den'
 
 [build]
+  [build.args]
+    VITE_COLLAB_ENABLED = "true"
+    VITE_API_BASE_URL = "https://d3d-api.fly.dev"
 
 [http_service]
   internal_port = 80
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ['app']
 
 [[vm]]


### PR DESCRIPTION
## Changes

### Fly.io build args
- `VITE_COLLAB_ENABLED=true` — activates the collab WebSocket client in the production build
- `VITE_API_BASE_URL=https://d3d-api.fly.dev` — points the frontend at the production API

### Fly.io machine config
- `min_machines_running = 1` — keeps at least one instance running so WebSocket connections from collab users are not dropped on idle

## Note
If the production API URL ever changes, update `VITE_API_BASE_URL` in `fly.toml` and redeploy.