### PR TITLE
feat(embed): Release 1 — inline embed, @d3dweb/embed package, ShareDialog Embed tab, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@
 
 # d3dweb
 
-**Real-time collaborative DAG editor. Vim-style keys. Zero-config sharing.**
+**Real-time collaborative DAG editor. Vim-style keys. Embeddable anywhere. AI-agent friendly.**
 
 [![Node](https://img.shields.io/badge/node-18%2B-3fb950?style=for-the-badge&logo=node.js&logoColor=white)](https://nodejs.org/)
 [![Vue 3](https://img.shields.io/badge/vue-3.4-41b883?style=for-the-badge&logo=vue.js&logoColor=white)](https://vuejs.org/)
 [![Vite](https://img.shields.io/badge/vite-5-646cff?style=for-the-badge&logo=vite&logoColor=white)](https://vitejs.dev/)
 [![Cytoscape](https://img.shields.io/badge/cytoscape-3.34-ff6b9d?style=for-the-badge)](https://js.cytoscape.org/)
 [![License](https://img.shields.io/badge/license-MIT-a78bfa?style=for-the-badge)](LICENSE)
+[![npm](https://img.shields.io/badge/npm-%40d3dweb%2Fembed-cb3837?style=for-the-badge&logo=npm)](https://www.npmjs.com/package/@d3dweb/embed)
 
-[**Live demo**](https://d3dweb.fly.dev) · [**Landing page**](https://smetroid.github.io/d3dweb/) · [**API**](https://github.com/smetroid/d3d-api) · [**Report bug**](https://github.com/smetroid/d3dweb/issues)
+[**Live demo**](https://d3dweb.fly.dev) · [**Landing page**](https://smetroid.github.io/d3dweb/) · [**API**](https://github.com/smetroid/d3d-api) · [**Render service**](https://github.com/smetroid/d3d-render) · [**Report bug**](https://github.com/smetroid/d3dweb/issues)
 
 </div>
 
@@ -24,7 +25,7 @@ You have a graph. You want to work on it _with someone else_, right now, without
 
 That's d3dweb.
 
-| For **users**                                 | For **engineers**                                                  |
+| For **users**                                 | For **engineers / AI agents**                                      |
 | --------------------------------------------- | ------------------------------------------------------------------ |
 | Multi-user editing with live avatars          | Vue 3 Options API — familiar and easy to fork                      |
 | Vim-style `hjkl` graph navigation             | Cytoscape.js core — swap layouts or extensions freely              |
@@ -32,6 +33,8 @@ That's d3dweb.
 | Share links with view/edit roles              | JWT share tokens with server-side revocation list                  |
 | Snapshot history + one-click restore          | 500ms debounced autosave with `clientId` echo prevention           |
 | View-only anonymous identities (`"Teal Fox"`) | Native WebSocket relay — no Redis, no CRDT server tax              |
+| **Embed diagrams in any markdown surface**    | `@d3dweb/embed` — encode graphlib JSON → URL, no account needed    |
+| **Fork an embedded diagram to your account**  | Agents emit graphlib JSON; d3d-render serves `image/svg+xml`       |
 | Every shortcut rebindable in Settings         | Fly.io deploy + release-please + Renovate + gitleaks preconfigured |
 
 ---
@@ -86,6 +89,83 @@ View-only guests get a random display name server-side. No sign-up, no email, no
 </td>
 </tr>
 </table>
+
+---
+
+## Embed in GitHub / anywhere
+
+Paste a d3dweb diagram into any markdown surface — GitHub READMEs, wikis, Notion, Confluence — with a single image tag. No login required to view.
+
+![Build → Test → Deploy pipeline](https://d3d-render.fly.dev/svg?src=eJx9jrkKwzAQRH8lTFpVzgUqQz4hXUghW-sDZK2wJJtg9O_BcY4ixu3MvN03gl1o2HrIEbrpqAikIUMXSaCNJjRVp1wNWSrjSaDg1nG0-h0kAcuaPORtRA-JPDZGQ6BXJtJ006icDCTOryIlMe8C-bA0u855wYY7SGz36liqw4_T5Aw_lsjLp_myGZ30LkNKdwHS1YLlsGLCduOir_-Uh1WLiVLeT0_TE7KFcVc&layout=dagre&theme=dark)
+
+> Click the image to open it in the live editor.
+
+### Portable embed (no account needed)
+
+The diagram is encoded directly in the URL. Copy the snippet from **Share → Embed → Inline** inside d3dweb, or generate it with `@d3dweb/embed`:
+
+```markdown
+![My diagram](https://d3d-render.fly.dev/svg?src=<encoded>&layout=dagre&theme=dark)
+```
+
+### Public embed (stable, revocable)
+
+Save the diagram to your account, toggle it public in **Share → Embed → By ID**, and use:
+
+```markdown
+![My diagram](https://d3d-render.fly.dev/svg?id=<dag-id>&layout=dagre&theme=dark)
+```
+
+The `?id=` embed updates automatically when you edit the diagram. Toggle public off to revoke access instantly.
+
+|                 | `?src=` Portable     | `?id=` Public              |
+| --------------- | -------------------- | -------------------------- |
+| Auth required   | No                   | Owner only (to set public) |
+| Updates on edit | No — snapshot in URL | Yes — live                 |
+| Revocable       | No                   | Yes                        |
+| Size limit      | 4 KB encoded         | Unlimited                  |
+
+---
+
+## For AI agents
+
+d3dweb diagrams are graphlib JSON — a format any LLM can emit. No account, no DSL, no tool-specific syntax.
+
+**Wire format** (3 required fields):
+
+```json
+{
+  "options": { "directed": true, "multigraph": false, "compound": false },
+  "nodes": [
+    { "v": "build", "value": { "label": "Build" } },
+    { "v": "test", "value": { "label": "Test" } },
+    { "v": "deploy", "value": { "label": "Deploy" } }
+  ],
+  "edges": [
+    { "v": "build", "w": "test", "value": { "label": "on push" } },
+    { "v": "test", "w": "deploy", "value": { "label": "on pass" } }
+  ]
+}
+```
+
+**Generate a shareable URL** with `@d3dweb/embed`:
+
+```js
+import { encode, embedUrl } from '@d3dweb/embed'
+
+const url = embedUrl({ src: encode(graphlibJson) })
+// → https://d3dweb.fly.dev/?src=<encoded>
+// Hand this URL to the user. No auth required.
+```
+
+The user opens the URL in d3dweb, sees the diagram in view-only mode, and can click **"Fork to my account"** to save and edit it.
+
+**Render to SVG/PNG** (for embedding in documents or reports):
+
+```
+GET https://d3d-render.fly.dev/svg?src=<encoded>&layout=dagre&theme=dark
+GET https://d3d-render.fly.dev/png?src=<encoded>&width=1200
+```
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -461,6 +461,17 @@
         line-height: 1.6;
       }
 
+      /* --- Embed preview --- */
+      .embed-preview {
+        margin-top: 2rem;
+        text-align: center;
+      }
+      .embed-caption {
+        margin-top: 0.75rem;
+        font-size: 0.8rem;
+        color: var(--text-dim);
+      }
+
       /* --- Split section --- */
       .split {
         display: grid;
@@ -666,8 +677,9 @@
           d3dweb
         </a>
         <div class="nav-links">
-          <a href="#features">Features</a>
-          <a href="#quickstart">Quick start</a>
+<a href="#features">Features</a>
+<a href="#embed">Embed</a>
+<a href="#quickstart">Quick start</a>
           <a href="#keys">Shortcuts</a>
           <a href="#layouts">Layouts</a>
           <a href="#architecture">Architecture</a>
@@ -816,6 +828,55 @@
             </div>
             <h3>Anonymous guests</h3>
             <p>View-only visitors get a server-generated name (<em>"Teal Fox"</em>). No sign-up. No PII. Persisted per share in localStorage.</p>
+          </div>
+        </div>
+      </section>
+
+      <section id="embed">
+        <div class="section-eyebrow">// embed</div>
+        <h2 class="section-title">Works everywhere markdown renders.</h2>
+        <p class="section-lede">Drop a d3dweb diagram into any GitHub README, wiki, or doc. No login required to view. One click to fork and edit.</p>
+
+        <div class="embed-preview">
+          <img
+            src="https://d3d-render.fly.dev/svg?src=eJx9jrkKwzAQRH8lTFpVzgUqQz4hXUghW-sDZK2wJJtg9O_BcY4ixu3MvN03gl1o2HrIEbrpqAikIUMXSaCNJjRVp1wNWSrjSaDg1nG0-h0kAcuaPORtRA-JPDZGQ6BXJtJ006icDCTOryIlMe8C-bA0u855wYY7SGz36liqw4_T5Aw_lsjLp_myGZ30LkNKdwHS1YLlsGLCduOir_-Uh1WLiVLeT0_TE7KFcVc&layout=dagre&theme=dark"
+            alt="Build → Test → Deploy pipeline rendered by d3d-render"
+            style="max-width:100%;border-radius:10px;border:1px solid rgba(255,255,255,0.08);"
+          />
+          <p class="embed-caption">↑ Live SVG — click to open in the editor</p>
+        </div>
+
+        <div class="features" style="margin-top:2rem;">
+          <div class="card">
+            <div class="icon">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#22d3ee" stroke-width="2">
+                <path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/>
+                <path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/>
+              </svg>
+            </div>
+            <h3>Portable embed</h3>
+            <p>Diagram encoded in the URL itself. No account, no expiry. Generate from <strong>Share → Embed → Inline</strong> or via <span class="mono">@d3dweb/embed</span>.</p>
+          </div>
+
+          <div class="card">
+            <div class="icon">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#a78bfa" stroke-width="2">
+                <circle cx="12" cy="12" r="10"/><path d="M12 8v4l3 3"/>
+              </svg>
+            </div>
+            <h3>Public by ID</h3>
+            <p>Toggle public in the Share dialog. Updates live when you edit. Revoke anytime. Use <span class="mono">?id=</span> for stable links that track diagram changes.</p>
+          </div>
+
+          <div class="card">
+            <div class="icon">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#4ade80" stroke-width="2">
+                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2z"/>
+                <path d="M9 12l2 2 4-4"/>
+              </svg>
+            </div>
+            <h3>AI-agent ready</h3>
+            <p>Agents emit graphlib JSON, encode with <span class="mono">@d3dweb/embed</span>, and hand the URL to the user. No auth. The user forks it with one click.</p>
           </div>
         </div>
       </section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "d3dweb",
       "version": "1.0.0",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "axios": "^1.6.7",
         "cytoscape": "^3.34.0",
@@ -595,6 +598,10 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/@d3dweb/embed": {
+      "resolved": "packages/embed",
+      "link": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -5052,6 +5059,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.2.0.tgz",
+      "integrity": "sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7064,6 +7087,13 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/embed": {
+      "name": "@d3dweb/embed",
+      "version": "0.1.0",
+      "dependencies": {
+        "pako": "^2.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "dev": "vite",
     "gen-icons": "node scripts/gen-mdi-icons.mjs",
@@ -11,7 +14,7 @@
     "preview": "vite preview",
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore",
     "test": "vitest run",
-    "format": "prettier --write src/",
+    "format": "prettier --write src/ packages/",
     "prepare": "husky"
   },
   "dependencies": {

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@d3dweb/embed",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "src/index.js",
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "dependencies": {
+    "pako": "^2.1.0"
+  }
+}

--- a/packages/embed/src/index.js
+++ b/packages/embed/src/index.js
@@ -1,0 +1,84 @@
+import { deflate, inflate } from 'pako'
+
+const MAX_ENCODED_BYTES = 4096
+const DEFAULT_HOST = 'd3dweb.fly.dev'
+
+export class EmbedSizeError extends Error {
+  constructor(bytes) {
+    super(
+      `Encoded diagram is ${bytes} bytes (max ${MAX_ENCODED_BYTES}). ` +
+        `Use embedUrl({ id }) with a public diagram instead.`
+    )
+    this.name = 'EmbedSizeError'
+    this.bytes = bytes
+  }
+}
+
+function toBase64url(bytes) {
+  let binary = ''
+  for (const b of bytes) binary += String.fromCharCode(b)
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+function fromBase64url(str) {
+  const padded =
+    str.replace(/-/g, '+').replace(/_/g, '/') + '=='.slice(0, (4 - (str.length % 4)) % 4)
+  const binary = atob(padded)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+  return bytes
+}
+
+/**
+ * Encode a graphlib JSON object into a compact base64url string.
+ * Throws EmbedSizeError if the result exceeds MAX_ENCODED_BYTES.
+ */
+export function encode(graphlibJson) {
+  const compressed = deflate(JSON.stringify(graphlibJson))
+  const encoded = toBase64url(compressed)
+  if (encoded.length > MAX_ENCODED_BYTES) {
+    throw new EmbedSizeError(encoded.length)
+  }
+  return encoded
+}
+
+/**
+ * Decode a base64url string back into a graphlib JSON object.
+ */
+export function decode(str) {
+  const bytes = fromBase64url(str)
+  return JSON.parse(inflate(bytes, { to: 'string' }))
+}
+
+/**
+ * Build a canonical embed URL for d3dweb or d3d-render.
+ *
+ * @param {object} opts
+ * @param {string} [opts.id]      - Public diagram ID (fetched by server)
+ * @param {string} [opts.src]     - Already-encoded diagram payload (from encode())
+ * @param {string} [opts.layout]  - Layout name (e.g. 'dagre', 'cola')
+ * @param {string} [opts.theme]   - 'light' | 'dark'
+ * @param {string} [opts.host]    - Host (default: d3dweb.fly.dev)
+ * @param {'svg'|'png'|null} [opts.render] - If set, targets d3d-render endpoint instead of SPA
+ * @param {string} [opts.renderHost] - Render service host (default: d3d-render.fly.dev)
+ * @returns {URL}
+ */
+export function embedUrl({ id, src, layout, theme, host, render, renderHost } = {}) {
+  if (!id && !src) throw new TypeError('embedUrl requires either id or src')
+  if (id && src) throw new TypeError('embedUrl accepts id or src, not both')
+
+  let base
+  if (render) {
+    const rh = renderHost || 'd3d-render.fly.dev'
+    base = `https://${rh}/${render}`
+  } else {
+    base = `https://${host || DEFAULT_HOST}/`
+  }
+
+  const url = new URL(base)
+  if (id) url.searchParams.set('id', id)
+  if (src) url.searchParams.set('src', src)
+  if (layout) url.searchParams.set('layout', layout)
+  if (theme) url.searchParams.set('theme', theme)
+  return url
+}

--- a/packages/embed/src/index.js
+++ b/packages/embed/src/index.js
@@ -47,7 +47,7 @@ export function encode(graphlibJson) {
  */
 export function decode(str) {
   const bytes = fromBase64url(str)
-  return JSON.parse(inflate(bytes, { to: 'string' }))
+  return JSON.parse(new TextDecoder().decode(inflate(bytes)))
 }
 
 /**

--- a/packages/embed/src/index.test.js
+++ b/packages/embed/src/index.test.js
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest'
+import { encode, decode, embedUrl, EmbedSizeError } from './index.js'
+
+const SMALL = {
+  options: { directed: true, multigraph: false, compound: true },
+  nodes: [
+    { v: 'api', value: { label: 'API' } },
+    { v: 'db', value: { label: 'DB' } }
+  ],
+  edges: [{ v: 'api', w: 'db', value: {} }]
+}
+
+const WITH_POSITIONS = {
+  options: { directed: true, multigraph: false, compound: true },
+  nodes: [
+    { v: 'a', value: { label: 'A', _x: 100, _y: 200 } },
+    { v: 'b', value: { label: 'B', _x: 300, _y: 200 } },
+    { v: 'c', value: { label: 'C', bgColor: '#ff0000', _x: 200, _y: 400 } }
+  ],
+  edges: [
+    { v: 'a', w: 'b', value: { label: 'calls' } },
+    { v: 'b', w: 'c', value: {} }
+  ]
+}
+
+const WITH_PARENT = {
+  options: { directed: true, multigraph: false, compound: true },
+  nodes: [
+    { v: 'cluster1', value: { label: 'Backend' } },
+    { v: 'svc', value: { label: 'Service' }, parent: 'cluster1' },
+    { v: 'db', value: { label: 'DB' }, parent: 'cluster1' }
+  ],
+  edges: [{ v: 'svc', w: 'db', value: {} }]
+}
+
+const EMPTY = {
+  options: { directed: true, multigraph: false, compound: true },
+  nodes: [],
+  edges: []
+}
+
+describe('encode / decode round-trip', () => {
+  for (const [name, graph] of Object.entries({ SMALL, WITH_POSITIONS, WITH_PARENT, EMPTY })) {
+    it(`round-trips ${name}`, () => {
+      const encoded = encode(graph)
+      expect(typeof encoded).toBe('string')
+      expect(encoded.length).toBeGreaterThan(0)
+      expect(decode(encoded)).toEqual(graph)
+    })
+  }
+
+  it('produces URL-safe characters only', () => {
+    const encoded = encode(SMALL)
+    expect(encoded).toMatch(/^[A-Za-z0-9\-_]+$/)
+  })
+
+  it('is deterministic for same input', () => {
+    expect(encode(SMALL)).toBe(encode(SMALL))
+  })
+})
+
+describe('size guard', () => {
+  it('throws EmbedSizeError when encoded payload exceeds 4096 bytes', () => {
+    const huge = {
+      options: { directed: true, multigraph: false, compound: true },
+      nodes: Array.from({ length: 400 }, (_, i) => ({
+        v: `node-${i}`,
+        value: {
+          label: `Node ${i}`,
+          description: `A longer description for node ${i} to increase payload size`
+        }
+      })),
+      edges: Array.from({ length: 399 }, (_, i) => ({
+        v: `node-${i}`,
+        w: `node-${i + 1}`,
+        value: {}
+      }))
+    }
+    expect(() => encode(huge)).toThrow(EmbedSizeError)
+  })
+
+  it('EmbedSizeError has bytes property', () => {
+    const huge = {
+      options: { directed: true, multigraph: false, compound: true },
+      nodes: Array.from({ length: 400 }, (_, i) => ({
+        v: `n${i}`,
+        value: {
+          label: `long label for node ${i} that adds up`,
+          extra: `padding-${i}-padding-${i}`
+        }
+      })),
+      edges: []
+    }
+    try {
+      encode(huge)
+    } catch (e) {
+      expect(e).toBeInstanceOf(EmbedSizeError)
+      expect(e.bytes).toBeGreaterThan(4096)
+    }
+  })
+})
+
+describe('embedUrl', () => {
+  it('builds SPA URL with id', () => {
+    const url = embedUrl({ id: 'abc123' })
+    expect(url.hostname).toBe('d3dweb.fly.dev')
+    expect(url.searchParams.get('id')).toBe('abc123')
+    expect(url.searchParams.get('src')).toBeNull()
+  })
+
+  it('builds SPA URL with src', () => {
+    const encoded = encode(SMALL)
+    const url = embedUrl({ src: encoded })
+    expect(url.searchParams.get('src')).toBe(encoded)
+    expect(url.searchParams.get('id')).toBeNull()
+  })
+
+  it('includes layout and theme params', () => {
+    const url = embedUrl({ id: 'x', layout: 'dagre', theme: 'dark' })
+    expect(url.searchParams.get('layout')).toBe('dagre')
+    expect(url.searchParams.get('theme')).toBe('dark')
+  })
+
+  it('uses custom host', () => {
+    const url = embedUrl({ id: 'x', host: 'localhost:5173' })
+    expect(url.host).toBe('localhost:5173')
+  })
+
+  it('targets render service SVG endpoint', () => {
+    const encoded = encode(SMALL)
+    const url = embedUrl({ src: encoded, render: 'svg' })
+    expect(url.hostname).toBe('d3d-render.fly.dev')
+    expect(url.pathname).toBe('/svg')
+    expect(url.searchParams.get('src')).toBe(encoded)
+  })
+
+  it('targets render service with custom renderHost', () => {
+    const url = embedUrl({ id: 'x', render: 'png', renderHost: 'render.d3dweb.dev' })
+    expect(url.hostname).toBe('render.d3dweb.dev')
+    expect(url.pathname).toBe('/png')
+  })
+
+  it('throws when neither id nor src provided', () => {
+    expect(() => embedUrl({})).toThrow(TypeError)
+  })
+
+  it('throws when both id and src provided', () => {
+    expect(() => embedUrl({ id: 'x', src: 'y' })).toThrow(TypeError)
+  })
+})

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,7 +7,8 @@ import Settings from '@/components/Settings.vue'
 import HelperPane from '@/components/Helper.vue'
 import GraphModel from '@/helpers/GraphModel.js'
 import DiagramGraph from '@/helpers/DiagramGraph.js'
-import { graphlibToModel, isGraphlibFormat } from '@/helpers/graphlibMigration.js'
+import { graphlibToModel, isGraphlibFormat, modelToGraphlib } from '@/helpers/graphlibMigration.js'
+import { decode as embedDecode } from '@d3dweb/embed'
 import { migrateDiagramPayload } from '@/helpers/legacyMigration.js'
 import DiagramForm from '@/components/DiagramForm.vue'
 import DiagramList from '@/components/DiagramList.vue'
@@ -61,7 +62,12 @@ function toggleTheme() {
         :d3dInfo="d3dInfo"
       />
       -->
-      <DiagramGraphView :active="active" />
+      <DiagramGraphView
+        :active="active"
+        :embed-mode="embedMode"
+        @fork-embed="forkEmbedDiagram"
+        @embed-login="() => emitter.emit('changeActive', 'Login')"
+      />
       <DiagramForm :active="active" />
       <Settings :active="active" :d3dInfo="d3dInfo" />
       <DiagramList :active="active" />
@@ -199,7 +205,8 @@ export default {
         }
       ],
       d3dInfo: {},
-      modifier: {}
+      modifier: {},
+      embedMode: false
     }
   },
   provide() {
@@ -207,7 +214,7 @@ export default {
       modifier: computed(() => this.modifier)
     }
   },
-  mounted() {
+  async mounted() {
     try {
       console.log('App mounted')
 
@@ -219,7 +226,10 @@ export default {
       this.syncThemeAttr()
       this.emitter.emit('themeChanged')
 
-      if (D3Util.auth()) {
+      const query = new URLSearchParams(window.location.search)
+      if (query.has('src') || query.has('id')) {
+        await this.loadEmbedLink(query)
+      } else if (D3Util.auth()) {
         this.loadFromServer()
       } else {
         this.loadDiagram()
@@ -563,6 +573,91 @@ export default {
           message: 'Unable to restore this snapshot',
           status: 'error'
         })
+      }
+    },
+    async loadEmbedLink(query) {
+      this.embedMode = true
+      const src = query.get('src')
+      const id = query.get('id')
+      const theme = query.get('theme')
+
+      try {
+        let graphlibJson,
+          name = 'Embedded Diagram',
+          description = ''
+
+        if (src) {
+          graphlibJson = embedDecode(src)
+        } else {
+          const data = await D3DApi.getDiagramPublic(id)
+          if (!data || !data.diagram) {
+            this.emitter.emit('appMessage', {
+              message: 'Diagram not found or not public',
+              status: 'error'
+            })
+            this.embedMode = false
+            this.loadDiagram()
+            return
+          }
+          graphlibJson = JSON.parse(data.diagram)
+          name = data.name || 'Embedded Diagram'
+          description = data.description || ''
+        }
+
+        const parsed = migrateDiagramPayload(graphlibJson)
+        const model = markRaw(
+          isGraphlibFormat(parsed) ? graphlibToModel(parsed) : new GraphModel(parsed)
+        )
+        model.colaConstraints = parsed.options?.constraints || []
+
+        this.d3dInfo = {
+          id: D3Util.randomId(),
+          name,
+          description,
+          created: new Date().toISOString(),
+          diagram: model,
+          colaConstraints: model.colaConstraints
+        }
+        const mod = markRaw(new DiagramGraph(this.d3dInfo, this.emitter))
+        mod._suppressSave = true
+        this.modifier = mod
+
+        if (theme === 'dark' || theme === 'light') {
+          this.$vuetify.theme.global.name = theme
+          this.syncThemeAttr()
+          this.emitter.emit('themeChanged')
+        }
+      } catch (err) {
+        console.error('embed load failed', err)
+        this.emitter.emit('appMessage', {
+          message: 'Failed to load embedded diagram',
+          status: 'error'
+        })
+        this.embedMode = false
+        this.loadDiagram()
+      }
+    },
+    async forkEmbedDiagram() {
+      if (!D3Util.auth()) return
+      try {
+        const graphlibJson = modelToGraphlib(this.d3dInfo.diagram)
+        const result = await D3DApi.postDiagram({
+          name: this.d3dInfo.name || 'Forked Diagram',
+          description: this.d3dInfo.description || '',
+          diagram: JSON.stringify(graphlibJson)
+        })
+        const newId = result?.data?.id || result?.id
+        if (newId) {
+          this.embedMode = false
+          await this.loadFromServer(newId)
+          this.emitter.emit('appMessage', {
+            message: 'Diagram forked — you can now edit it',
+            status: 'success'
+          })
+        }
+      } catch (err) {
+        console.error('fork failed', err)
+        this.emitter.emit('appMessage', { message: 'Failed to fork diagram', status: 'error' })
       }
     },
     d3Action: async function (event) {

--- a/src/components/DiagramGraphView.vue
+++ b/src/components/DiagramGraphView.vue
@@ -58,6 +58,19 @@
         </div>
 
         <div v-if="isViewOnly" class="view-only-badge">VIEW ONLY</div>
+        <div v-if="embedMode" class="embed-fork-bar">
+          <button
+            v-if="isLoggedIn"
+            class="embed-fork-btn"
+            title="Save a copy to your account"
+            @click="$emit('fork-embed')"
+          >
+            Fork to my account
+          </button>
+          <span v-else class="embed-login-hint">
+            <a href="#" @click.prevent="$emit('embed-login')">Log in</a> to fork this diagram
+          </span>
+        </div>
 
         <div v-if="graphEmpty" class="graph-empty-hint">
           Empty diagram — press <span class="kbd">n</span> to create a node
@@ -150,7 +163,8 @@ function _sessionColor() {
 
 export default {
   name: 'DiagramGraphView',
-  props: ['active'],
+  props: ['active', 'embedMode'],
+  emits: ['fork-embed', 'embed-login'],
   inject: ['modifier'],
   components: { D3NodeForm, D3EdgeForm, HistoryPanel, ShareDialog },
   data() {
@@ -626,7 +640,10 @@ export default {
       return Object.keys(this.peers).length > 0
     },
     isViewOnly() {
-      return _isViewOnly()
+      return !!this.embedMode || _isViewOnly()
+    },
+    isLoggedIn() {
+      return D3Util.auth()
     }
   },
   watch: {
@@ -832,5 +849,48 @@ h2 {
   font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
   letter-spacing: 0.08em;
   pointer-events: none;
+}
+
+.embed-fork-bar {
+  position: absolute;
+  bottom: 12px;
+  right: 12px;
+  z-index: 6;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.embed-fork-btn {
+  padding: 6px 14px;
+  border-radius: 6px;
+  border: 1px solid rgba(var(--fx-accent), 0.6);
+  background: rgba(var(--fx-glass-bottom), 0.9);
+  color: rgb(var(--fx-ink));
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  backdrop-filter: blur(10px);
+  transition: background 0.15s;
+}
+
+.embed-fork-btn:hover {
+  background: rgba(var(--fx-accent), 0.2);
+}
+
+.embed-login-hint {
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  font-size: 11px;
+  color: rgba(var(--fx-ink), 0.7);
+  background: rgba(var(--fx-glass-bottom), 0.85);
+  padding: 6px 12px;
+  border-radius: 6px;
+  backdrop-filter: blur(10px);
+}
+
+.embed-login-hint a {
+  color: rgb(var(--fx-accent));
+  text-decoration: none;
 }
 </style>

--- a/src/components/DiagramGraphView.vue
+++ b/src/components/DiagramGraphView.vue
@@ -118,6 +118,7 @@
         <div v-if="showShare" class="fx-hud-stage">
           <ShareDialog
             :dagId="(modifier?.value ?? modifier)?.d3dInfo?.id"
+            :graphlibJson="graphlibJson"
             @close="showShare = false"
           />
         </div>
@@ -129,6 +130,7 @@
 <script>
 import D3Util from '@/helpers/D3Util'
 import CytoscapeRenderer from '@/helpers/CytoscapeRenderer'
+import { modelToGraphlib } from '@/helpers/graphlibMigration'
 import { markRaw } from 'vue'
 import D3EdgeForm from '@/components/D3EdgeForm.vue'
 import D3NodeForm from '@/components/D3NodeForm.vue'
@@ -644,6 +646,10 @@ export default {
     },
     isLoggedIn() {
       return D3Util.auth()
+    },
+    graphlibJson() {
+      const mod = this.modifier?.value ?? this.modifier
+      return mod ? modelToGraphlib(mod) : null
     }
   },
   watch: {

--- a/src/components/ShareDialog.vue
+++ b/src/components/ShareDialog.vue
@@ -5,76 +5,176 @@
         <header class="fx-panel-header">
           <div class="fx-panel-title">
             <span class="fx-title-chip fx-chip-edit">SHR</span>
-            <h2 class="fx-title">SHARE</h2>
+            <h2 class="fx-title">{{ activeTab === 'share' ? 'SHARE' : 'EMBED' }}</h2>
           </div>
           <button type="button" class="fx-close" aria-label="Close" @click="$emit('close')">
             ✕
           </button>
         </header>
 
+        <div class="tab-bar">
+          <button
+            class="tab-btn"
+            :class="{ active: activeTab === 'share' }"
+            @click="activeTab = 'share'"
+          >
+            Share
+          </button>
+          <button class="tab-btn" :class="{ active: activeTab === 'embed' }" @click="switchToEmbed">
+            Embed
+          </button>
+        </div>
+
         <div class="fx-panel-body">
-          <div class="share-form">
-            <div class="share-field">
-              <label class="share-label">ROLE</label>
-              <div class="share-seg">
-                <button
-                  class="share-seg-btn"
-                  :class="{ active: role === 'view' }"
-                  @click="role = 'view'"
-                >
-                  View
-                </button>
-                <button
-                  class="share-seg-btn"
-                  :class="{ active: role === 'edit' }"
-                  @click="role = 'edit'"
-                >
-                  Edit
-                </button>
+          <!-- SHARE TAB -->
+          <template v-if="activeTab === 'share'">
+            <div class="share-form">
+              <div class="share-field">
+                <label class="share-label">ROLE</label>
+                <div class="share-seg">
+                  <button
+                    class="share-seg-btn"
+                    :class="{ active: role === 'view' }"
+                    @click="role = 'view'"
+                  >
+                    View
+                  </button>
+                  <button
+                    class="share-seg-btn"
+                    :class="{ active: role === 'edit' }"
+                    @click="role = 'edit'"
+                  >
+                    Edit
+                  </button>
+                </div>
               </div>
-            </div>
 
-            <div class="share-field">
-              <label class="share-label">EXPIRES IN</label>
-              <div class="share-seg">
-                <button
-                  v-for="d in [1, 7, 30]"
-                  :key="d"
-                  class="share-seg-btn"
-                  :class="{ active: expDays === d }"
-                  @click="expDays = d"
-                >
-                  {{ d }}d
-                </button>
+              <div class="share-field">
+                <label class="share-label">EXPIRES IN</label>
+                <div class="share-seg">
+                  <button
+                    v-for="d in [1, 7, 30]"
+                    :key="d"
+                    class="share-seg-btn"
+                    :class="{ active: expDays === d }"
+                    @click="expDays = d"
+                  >
+                    {{ d }}d
+                  </button>
+                </div>
               </div>
-            </div>
 
-            <button class="share-generate-btn" :disabled="generating" @click="generate">
-              {{ generating ? 'Generating…' : 'Generate Link' }}
-            </button>
-          </div>
-
-          <div v-if="generatedLink" class="share-result">
-            <div class="share-link-row">
-              <input
-                ref="linkInput"
-                class="share-link-input"
-                :value="generatedLink"
-                readonly
-                @click="selectAll"
-              />
-              <button class="share-copy-btn" :class="{ copied }" @click="copyLink">
-                {{ copied ? '✓' : 'Copy' }}
+              <button class="share-generate-btn" :disabled="generating" @click="generate">
+                {{ generating ? 'Generating…' : 'Generate Link' }}
               </button>
             </div>
-            <p class="share-hint">
-              Anyone with this link can {{ role }} this diagram for {{ expDays }} day{{
-                expDays !== 1 ? 's' : ''
-              }}.
-            </p>
-          </div>
 
-          <div v-if="errorMsg" class="share-error">{{ errorMsg }}</div>
+            <div v-if="generatedLink" class="share-result">
+              <div class="share-link-row">
+                <input
+                  ref="linkInput"
+                  class="share-link-input"
+                  :value="generatedLink"
+                  readonly
+                  @click="selectAll"
+                />
+                <button class="share-copy-btn" :class="{ copied }" @click="copyLink">
+                  {{ copied ? '✓' : 'Copy' }}
+                </button>
+              </div>
+              <p class="share-hint">
+                Anyone with this link can {{ role }} this diagram for {{ expDays }} day{{
+                  expDays !== 1 ? 's' : ''
+                }}.
+              </p>
+            </div>
+
+            <div v-if="shareErrorMsg" class="share-error">{{ shareErrorMsg }}</div>
+          </template>
+
+          <!-- EMBED TAB -->
+          <template v-else>
+            <div class="share-field">
+              <label class="share-label">MODE</label>
+              <div class="share-seg">
+                <button
+                  class="share-seg-btn"
+                  :class="{ active: embedMode === 'inline' }"
+                  @click="embedMode = 'inline'"
+                >
+                  Inline
+                </button>
+                <button
+                  class="share-seg-btn"
+                  :class="{ active: embedMode === 'byid' }"
+                  @click="embedMode = 'byid'"
+                >
+                  By ID
+                </button>
+              </div>
+            </div>
+
+            <!-- Inline mode -->
+            <template v-if="embedMode === 'inline'">
+              <div v-if="inlineUrl" class="share-result">
+                <p class="share-hint">Diagram encoded inline — works without login, no expiry.</p>
+                <div class="share-link-row">
+                  <input
+                    ref="inlineLinkInput"
+                    class="share-link-input"
+                    :value="inlineUrl"
+                    readonly
+                    @click="$refs.inlineLinkInput?.select()"
+                  />
+                  <button
+                    class="share-copy-btn"
+                    :class="{ copied: inlineCopied }"
+                    @click="copyInline"
+                  >
+                    {{ inlineCopied ? '✓' : 'Copy' }}
+                  </button>
+                </div>
+              </div>
+              <div v-else-if="inlineSizeError" class="share-error">{{ inlineSizeError }}</div>
+            </template>
+
+            <!-- By ID mode -->
+            <template v-else>
+              <div class="embed-public-row">
+                <span class="share-label">PUBLIC</span>
+                <button
+                  class="public-toggle"
+                  :class="{ on: isPublic }"
+                  :disabled="publicLoading || publicToggling"
+                  @click="togglePublic"
+                >
+                  {{ publicLoading ? '…' : isPublic ? 'On' : 'Off' }}
+                </button>
+              </div>
+              <p class="share-hint">
+                {{
+                  isPublic
+                    ? 'Anyone with the link can view this diagram.'
+                    : 'Make this diagram public to embed by ID.'
+                }}
+              </p>
+              <div v-if="isPublic && byIdUrl" class="share-result">
+                <div class="share-link-row">
+                  <input
+                    ref="idLinkInput"
+                    class="share-link-input"
+                    :value="byIdUrl"
+                    readonly
+                    @click="$refs.idLinkInput?.select()"
+                  />
+                  <button class="share-copy-btn" :class="{ copied: idCopied }" @click="copyById">
+                    {{ idCopied ? '✓' : 'Copy' }}
+                  </button>
+                </div>
+              </div>
+              <div v-if="embedErrorMsg" class="share-error">{{ embedErrorMsg }}</div>
+            </template>
+          </template>
         </div>
       </div>
     </focus-trap>
@@ -82,39 +182,59 @@
 </template>
 
 <script>
+import { encode, embedUrl, EmbedSizeError } from '@d3dweb/embed'
 import api from '@/services/api'
 
 export default {
   name: 'ShareDialog',
   props: {
-    dagId: { type: String, required: true }
+    dagId: { type: String, required: true },
+    graphlibJson: { type: Object, default: null }
   },
   emits: ['close'],
   data() {
     return {
       enableTrap: true,
+      activeTab: 'share',
+      // share tab
       role: 'view',
       expDays: 7,
       generating: false,
       generatedLink: null,
       copied: false,
-      errorMsg: null
+      shareErrorMsg: null,
+      // embed tab
+      embedMode: 'inline',
+      inlineUrl: null,
+      inlineSizeError: null,
+      inlineCopied: false,
+      isPublic: false,
+      publicLoading: false,
+      publicToggling: false,
+      idCopied: false,
+      embedErrorMsg: null
+    }
+  },
+  computed: {
+    byIdUrl() {
+      if (!this.isPublic || !this.dagId) return null
+      return embedUrl({ id: this.dagId, host: window.location.origin })
     }
   },
   methods: {
     async generate() {
       this.generating = true
       this.generatedLink = null
-      this.errorMsg = null
+      this.shareErrorMsg = null
       try {
         const data = await api.createShare(this.dagId, { role: this.role, expDays: this.expDays })
         if (data?.token) {
           this.generatedLink = window.location.origin + '/join/' + data.token
         } else {
-          this.errorMsg = data?.error || 'Failed to generate link'
+          this.shareErrorMsg = data?.error || 'Failed to generate link'
         }
       } catch {
-        this.errorMsg = 'Failed to generate link'
+        this.shareErrorMsg = 'Failed to generate link'
       } finally {
         this.generating = false
       }
@@ -125,22 +245,121 @@ export default {
       try {
         await navigator.clipboard.writeText(this.generatedLink)
         this.copied = true
-        setTimeout(() => {
-          this.copied = false
-        }, 2000)
+        setTimeout(() => (this.copied = false), 2000)
       } catch {
-        this.selectAll()
+        this.$refs.linkInput?.select()
       }
     },
 
     selectAll() {
       this.$refs.linkInput?.select()
+    },
+
+    switchToEmbed() {
+      this.activeTab = 'embed'
+      this.buildInlineUrl()
+      this.loadPublicStatus()
+    },
+
+    buildInlineUrl() {
+      if (!this.graphlibJson) return
+      try {
+        this.inlineUrl = embedUrl({ src: encode(this.graphlibJson), host: window.location.origin })
+        this.inlineSizeError = null
+      } catch (e) {
+        if (e instanceof EmbedSizeError) {
+          this.inlineUrl = null
+          this.inlineSizeError = `Diagram too large for inline embed (${e.bytes} bytes). Use "By ID" instead.`
+        } else {
+          throw e
+        }
+      }
+    },
+
+    async loadPublicStatus() {
+      if (!this.dagId) return
+      this.publicLoading = true
+      try {
+        await api.getDiagramPublic(this.dagId)
+        this.isPublic = true
+      } catch {
+        this.isPublic = false
+      } finally {
+        this.publicLoading = false
+      }
+    },
+
+    async togglePublic() {
+      this.publicToggling = true
+      this.embedErrorMsg = null
+      try {
+        await api.setDiagramPublic(this.dagId, !this.isPublic)
+        this.isPublic = !this.isPublic
+      } catch {
+        this.embedErrorMsg = 'Failed to update visibility'
+      } finally {
+        this.publicToggling = false
+      }
+    },
+
+    async copyInline() {
+      if (!this.inlineUrl) return
+      try {
+        await navigator.clipboard.writeText(this.inlineUrl)
+        this.inlineCopied = true
+        setTimeout(() => (this.inlineCopied = false), 2000)
+      } catch {
+        this.$refs.inlineLinkInput?.select()
+      }
+    },
+
+    async copyById() {
+      if (!this.byIdUrl) return
+      try {
+        await navigator.clipboard.writeText(this.byIdUrl)
+        this.idCopied = true
+        setTimeout(() => (this.idCopied = false), 2000)
+      } catch {
+        this.$refs.idLinkInput?.select()
+      }
     }
   }
 }
 </script>
 
 <style scoped>
+.tab-bar {
+  display: flex;
+  border-bottom: 1px solid rgba(var(--fx-accent), 0.15);
+  padding: 0 16px;
+}
+
+.tab-btn {
+  padding: 6px 14px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  color: rgb(var(--fx-ink-dim));
+  font-size: 11px;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  transition:
+    color 0.12s,
+    border-color 0.12s;
+  margin-bottom: -1px;
+}
+
+.tab-btn.active {
+  color: rgb(var(--fx-ink));
+  border-bottom-color: rgba(var(--fx-accent), 0.7);
+}
+
+.tab-btn:hover:not(.active) {
+  color: rgb(var(--fx-ink));
+}
+
 .fx-panel-body {
   overflow-y: auto;
   flex: 1;
@@ -282,5 +501,44 @@ export default {
   font-size: 12px;
   color: #ef5350;
   padding: 8px 0;
+}
+
+.embed-public-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.public-toggle {
+  padding: 4px 14px;
+  border-radius: 5px;
+  border: 1px solid rgba(var(--fx-accent), 0.3);
+  background: transparent;
+  color: rgb(var(--fx-ink-dim));
+  font-size: 11px;
+  font-family: 'JetBrains Mono', 'SFMono-Regular', Consolas, monospace;
+  cursor: pointer;
+  transition:
+    background 0.12s,
+    color 0.12s,
+    border-color 0.12s;
+  min-width: 52px;
+  text-align: center;
+}
+
+.public-toggle.on {
+  background: rgba(76, 175, 80, 0.18);
+  color: #4caf50;
+  border-color: rgba(76, 175, 80, 0.5);
+}
+
+.public-toggle:hover:not(:disabled):not(.on) {
+  background: rgba(var(--fx-accent), 0.07);
+  color: rgb(var(--fx-ink));
+}
+
+.public-toggle:disabled {
+  opacity: 0.5;
+  cursor: default;
 }
 </style>

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -41,6 +41,12 @@ export default {
         console.log('getDiagram finished')
       })
   },
+  async getDiagramPublic(id) {
+    return api()
+      .get('/dag/' + id + '/public')
+      .then((response) => response.data)
+      .catch((error) => error)
+  },
   async getDiagrams() {
     return api()
       .get('/dags', { headers: { Authorization: 'Bearer ' + localStorage.getItem('token') } })
@@ -114,6 +120,18 @@ export default {
   async exchangeShare(token) {
     return api()
       .get('/shares/exchange', { params: { token } })
+      .then((response) => response.data)
+      .catch((error) => error)
+  },
+  async setDiagramPublic(id, isPublic) {
+    return api()
+      .patch(
+        '/dag/' + id,
+        { public: isPublic },
+        {
+          headers: { Authorization: 'Bearer ' + localStorage.getItem('token') }
+        }
+      )
       .then((response) => response.data)
       .catch((error) => error)
   },


### PR DESCRIPTION
## Release 1: GitHub embed + agent data

Closes #54 #55 #56 #57 #58

### What's in this PR

**`@d3dweb/embed` package** (packages/embed/)
- `encode(graphlibJson)` → pako base64url string
- `decode(str)` → graphlib JSON
- `embedUrl({ src, id, host, layout, theme })` → canonical URL
- `EmbedSizeError` for >4 KB encoded payloads
- Fix: use `TextDecoder` for pako v2 (dropped `{ to: 'string' }`)

**SPA deep-link** (`?src=` / `?id=`) — closes #56
- `App.vue mounted()` detects embed params and loads diagram in view-only mode
- `_suppressSave` guard prevents autosave in embed mode
- Fork-to-account flow: posts to API, clears embed mode
- `getDiagramPublic` / `setDiagramPublic` in api.js

**ShareDialog Embed tab** — closes #57
- New tab bar: Share | Embed
- Inline mode: encode current diagram → `?src=` URL + copy
- By ID mode: toggle public via API → `?id=` URL + copy
- `graphlibJson` computed passed from DiagramGraphView

**README + landing page** — closes #58
- Live SVG embed example pointing at d3d-render
- Embed in GitHub / anywhere section with portable vs public comparison
- For AI agents section with graphlib JSON shape + `@d3dweb/embed` usage
- Landing page Embed section with live preview card

### Related repos
- d3d-api: smetroid/d3d-api#35 #36 (public flag + endpoint)
- d3d-render: smetroid/d3d-render (new service — headless SVG/PNG renderer)